### PR TITLE
🏯 PR: Support Multiple Material Orders Creation + Return CT Key Field

### DIFF
--- a/next-api/src/app/api/material-order/route.js
+++ b/next-api/src/app/api/material-order/route.js
@@ -146,7 +146,7 @@ export async function POST(request) {
     }
 
     const { MOID, actionLog } = await prisma.$transaction(async (tx) => {
-      const MOID = await generateID("MO-", "materialorder", "MOID");
+      const MOID = await generateID("MO-", "materialorder", "MOID", tx);
 
       await tx.materialorder.create({
         data: {
@@ -168,6 +168,7 @@ export async function POST(request) {
               Price: part.Price != null ? parseFloat(part.Price) : 0,
               Quantity: part.qty || 1,
               Status: "New",
+              RemovedPartNumber: part.RemovedPartNumber ?? null,
               materialorder: { connect: { MOID } },
               servicecatalog_parts: part.PartNumber
                 ? { connect: { PartNumber: part.PartNumber } }

--- a/next-api/src/app/api/service-log/create-order/route.js
+++ b/next-api/src/app/api/service-log/create-order/route.js
@@ -27,13 +27,10 @@ export async function POST(request) {
         const previousCaseStatus = caseInfo.CaseStatus;
 
         // start atomic transaction
-        const { WOID, MOID, actionLogs } = await prisma.$transaction(async (tx) => {
+        const { WOID, MOIDs, actionLogs } = await prisma.$transaction(async (tx) => {
             //Generate ID
-            const WOID = await generateID("WO-", "workorder", "WOID"); 
+            const WOID = await generateID("WO-", "workorder", "WOID", tx); 
             console.log("Generated ID:", WOID, typeof WOID);
-
-            const MOID = await generateID("MO-", "materialorder", "MOID");
-            console.log("Generated MOID:", MOID, typeof MOID);
 
             // 1. Create Work Order
             await tx.workorder.create({
@@ -65,35 +62,77 @@ export async function POST(request) {
                 data: { ServiceCatalogID: createdServiceCatalog.ServiceCatalogID }
             });
 
-            // 3. Create Material Order (One only)
-            await tx.materialorder.create({
-                data: {
-                MOID,
-                WOID,
-                OrderStatus: "New",
-                OrderType: "Repair",
-                OwnerID: materialOrderOwnerID
-                }
-            });
-
-            // 4. Create MaterialOrderLineItems
-            await Promise.all(selectedPartCatalog.map((part, i) =>
-                tx.materialorderlineitems.create({
+            // 3. Create Multiple Material Orders: one per selected part
+            const createdMOIDs = [];
+            const perMologs = [];
+            let lineNumber = 1;
+            for (const part of selectedPartCatalog) {
+                const MOID = await generateID("MO-", "materialorder", "MOID", tx);
+                console.log("MOID : ",MOID)
+                await tx.materialorder.create({
                     data: {
-                        LineNumber: i + 1,
+                        MOID,
+                        WOID,
+                        OrderStatus: "New",
+                        OrderType: "Repair",
+                        OwnerID: materialOrderOwnerID,
+                    }
+                });
+
+                await tx.materialorderlineitems.create({
+                    data: {
+                        LineNumber: lineNumber++,
                         Description: part.PartDescription,
-                        Price: parseFloat(part.Price),
+                        Price: part.Price != null ? parseFloat(part.Price) : 0,
                         Quantity: part.qty || 1,
                         Status: "New",
-                        materialorder: {
-                            connect: { MOID },
-                        },
-                        servicecatalog_parts: {
-                            connect: { PartNumber: part.PartNumber },
-                        },
+                        RemovedPartNumber: part.RemovedPartNumber ?? null,
+                        materialorder: { connect: { MOID } },
+                        servicecatalog_parts: part.PartNumber
+                            ? { connect: { PartNumber: part.PartNumber } }
+                            : undefined,
                     },
-                })
-            ));
+                });
+
+                // Per-MO case note
+                const noteText = `[NOTICE] Order Part\n` +
+                  `Order Part : ${part.PartNumber ?? "-"} - ${part.PartDescription ?? "-"}\n` +
+                  `${part.Price ? `Harga : Rp. ${part.Price}\n` : ""}` +
+                  `${part.RemovedPartNumber ? `Return CT Key : ${part.RemovedPartNumber}\n` : ""}` +
+                  `Requested to APO : ${assignApo ?? materialOrderOwnerID ?? "-"}`;
+                await tx.casenotes.create({
+                    data:{
+                        CaseID,
+                        LogType: "NotesLog",
+                        ActionType: "Action Plan",
+                        Template: "",
+                        VisibleExternally: true,
+                        MinutesSpent: 0,
+                        Note: noteText,
+                        CreatedBy: OwnerID
+                    }
+                });
+
+                // Per-MO action log
+                const perMoLog = await tx.ActionLog.create({
+                    data:{
+                        CaseID_toActionLog:{
+                            connect:{ CaseID }
+                        },
+                        ReferenceId: MOID,
+                        model: "Material Order",
+                        dataOld: "New",
+                        dataNew: "New",
+                        changedByUser: {
+                            connect: { IDUser: OwnerID },
+                        },
+                        logDescription: `New Material Order : ${MOID}`
+                    }
+                });
+
+                perMologs.push(perMoLog);
+                createdMOIDs.push(MOID);
+            }
             // for (const [i, part] of selectedPartCatalog.entries()) {
             //     await tx.materialorderlineitems.create({
             //     data: {
@@ -115,19 +154,21 @@ export async function POST(request) {
             //     });
             // }
 
-            // 5. Log Note inform Part Order
-            await tx.casenotes.create({
-                data:{
-                    CaseID,
-                    LogType: "NotesLog",
-                    ActionType: "Action Plan",
-                    Template: "",
-                    VisibleExternally: true,
-                    MinutesSpent: 0,
-                    Note: notesLog,
-                    CreatedBy: OwnerID
-                }
-            })
+            // 5. (Optional) Global log note if provided
+            if (notesLog) {
+                await tx.casenotes.create({
+                    data:{
+                        CaseID,
+                        LogType: "NotesLog",
+                        ActionType: "Action Plan",
+                        Template: "",
+                        VisibleExternally: true,
+                        MinutesSpent: 0,
+                        Note: notesLog,
+                        CreatedBy: OwnerID
+                    }
+                })
+            }
             
             // 6. Change Case Status to Part Request
             const caseUpdateData = {
@@ -180,26 +221,9 @@ export async function POST(request) {
                 }
             })
             
-            // 9. Action Log create Material Order 
-            const log3 = await tx.ActionLog.create({
-                data:{
-                    CaseID_toActionLog:{
-                        connect:{
-                            CaseID: CaseID
-                        }
-                    },
-                    ReferenceId: MOID,
-                    model: "Material Order",
-                    dataOld: "New",
-                    dataNew: "New",
-                    changedByUser: {
-                        connect: { IDUser: OwnerID },
-                    },
-                    logDescription: `New Material Order : ${MOID}`
-                }
-            })
+            // 9. Action Logs for Material Orders already created per part
 
-            return { WOID, MOID, actionLogs: [log1, log2, log3] };
+            return { WOID, MOIDs: createdMOIDs, actionLogs: [log1, log2, ...perMologs] };
         }, { timeout: 20000 })
 
         const { Owner, CreatedBy } = caseInfo;
@@ -217,7 +241,9 @@ export async function POST(request) {
             success: true, 
             message: "Order created successfully", 
             WOID,
-            MOID,
+            MOID: (MOIDs && MOIDs.length > 0) ? MOIDs[MOIDs.length - 1] : undefined,
+            MOIDs,
+            many: Array.isArray(MOIDs) && MOIDs.length > 1
         });
 
 

--- a/next-api/src/utils/generateID.js
+++ b/next-api/src/utils/generateID.js
@@ -1,8 +1,10 @@
 import prisma from "../../prisma/client";
 
-export async function generateID(prefix, modelName, idField) {
+// Accept an optional Prisma client (e.g., transaction 'tx') to ensure
+// ID generation sees writes within the same transaction/connection.
+export async function generateID(prefix, modelName, idField, client = prisma) {
   // Cari ID terakhir berdasarkan urutan DESC
-  const lastRecord = await prisma[modelName].findFirst({
+  const lastRecord = await client[modelName].findFirst({
     where: {
       [idField]: {
         startsWith: prefix,

--- a/test-vite/src/components/model/sc-modal.jsx
+++ b/test-vite/src/components/model/sc-modal.jsx
@@ -4857,6 +4857,14 @@ export function BtnModalsServiceCatalog({
     );
   };
 
+  const handleRemovedPartNumberChange = (partNumber, value) => {
+    setSelectedPartCatalog((prev) =>
+      prev.map((item) => (
+        item.PartNumber === partNumber ? { ...item, RemovedPartNumber: value } : item
+      ))
+    );
+  };
+
   //handle add part in confirm services
   const [tempSelectedParts, setTempSelectedParts] = useState([]);
   
@@ -4925,13 +4933,21 @@ Requested to APO : ${assignApo}`;
         // If WOID present or special mode, create only MO for existing WO
         const isCreateMOOnly = !!WOID || serviceCatalogType === 'wo-add-mo';
         const res = isCreateMOOnly
-          ? await ApiCustomer.post("/api/material-order", {
-              WOID: WOID,
-              selectedPartCatalog,
-              OwnerID: data.user.id,
-              assignApo: assignApo,
-              notesLog: noteCreateOrderLog,
-            })
+          ? await (async () => {
+              const createdMOIDs = [];
+              for (const part of selectedPartCatalog) {
+                const note = `[NOTICE] Order Part\nOrder Part : ${part.PartNumber} - ${part.PartDescription}\n${part.Price ? `Harga : Rp. ${part.Price}\n` : ''}${part.RemovedPartNumber ? `Return CT Key : ${part.RemovedPartNumber}\n` : ''}Requested to APO : ${assignApo}`;
+                const r = await ApiCustomer.post("/api/material-order", {
+                  WOID: WOID,
+                  selectedPartCatalog: [{ ...part, qty: part.qty || 1 }],
+                  OwnerID: data.user.id,
+                  assignApo: assignApo,
+                  notesLog: note,
+                });
+                if (r?.data?.MOID) createdMOIDs.push(r.data.MOID);
+              }
+              return { data: { many: true, MOIDs: createdMOIDs } };
+            })()
           : await ApiCustomer.post("/api/service-log/create-order", {
               AssetID: assetForWorkOrderCreation.AssetID,
               CaseID: caseDetails.CaseID,
@@ -4957,20 +4973,35 @@ Requested to APO : ${assignApo}`;
           allowEscapeKey: false,
         }).then(()=>{
           setOpen(false);
-          const WOID = res.data.WOID
+          const WOIDRes = res.data.WOID
           const MOID = res.data.MOID
-          switch (serviceCatalogType) {
-            case "CSR":
+          if (isCreateMOOnly) {
+            if (res.data?.many && Array.isArray(res.data.MOIDs) && res.data.MOIDs.length) {
+              // could open the last MO, keep silent here per prior behavior
+            } else if (MOID) {
               window.open(`/app/material-order/${MOID}`, '_blank');
-              break;
+            }
+          } else {
+            // handle multi-MO creation from create-order
+            const manyCreate = res.data?.many && Array.isArray(res.data.MOIDs) && res.data.MOIDs.length;
+            switch (serviceCatalogType) {
+              case "CSR":
+                if (manyCreate) {
+                  // Open the last created MO or keep on WO page as desired
+                  // window.open(`/app/material-order/${res.data.MOIDs.slice(-1)[0]}`, '_blank');
+                } else if (MOID) {
+                  window.open(`/app/material-order/${MOID}`, '_blank');
+                }
+                break;
 
-            case "serviceorder":
-              window.open(`/app/work/${WOID}`, '_blank');  
-              break;
-
-            default:
-              break;
-
+              case "serviceorder":
+                window.open(`/app/work/${WOIDRes}`, '_blank');  
+                break;
+  
+              default:
+                break;
+  
+            }
           }
         });
       } catch (err) {
@@ -5266,11 +5297,11 @@ Requested to APO : ${assignApo}`;
                       );
                     })}
 
-                    {/* pagination row */}
-                    <TableRow>
-                      <TableCell colSpan="100%">
-                        <Pagination className="flex justify-start">
-                          <PaginationContent>
+                {/* pagination row */}
+                <TableRow>
+                  <TableCell colSpan="100%">
+                    <Pagination className="flex justify-start">
+                      <PaginationContent>
                             <PaginationItem>
                               <PaginationPrevious
                                 href="#"
@@ -5385,6 +5416,7 @@ Requested to APO : ${assignApo}`;
                     <TableHead className={'font-bold text-black'}>Unit Price</TableHead>
                     <TableHead className={'font-bold text-black'}>Shipping Fee</TableHead>
                     <TableHead className={'font-bold text-black'}>Qty</TableHead>
+                    <TableHead className={'font-bold text-black'}>CT KEY RETURN</TableHead>
                     <TableHead className={'font-bold text-black'}>Tax</TableHead>
                     <TableHead className={'font-bold text-black'}>Price</TableHead>
                   </TableRow>
@@ -5403,7 +5435,15 @@ Requested to APO : ${assignApo}`;
                         <TableCell>{part.PartNumber}</TableCell>
                         <TableCell>{part.PartDescription}</TableCell>
                         <TableCell>{part.Shipping_Fee}</TableCell>
-                        <TableCell>{part.qty}
+                        <TableCell>{part.qty} </TableCell>
+                        <TableCell>
+
+                          <Input
+                            placeholder="Enter Return CT Key"
+                            className="bg-white"
+                            value={part.RemovedPartNumber || ''}
+                            onChange={(e) => handleRemovedPartNumberChange(part.PartNumber, e.target.value)}
+                          />
                         {/* <Input
                           placeholder="QTY"
                           min={1}
@@ -5432,6 +5472,7 @@ Requested to APO : ${assignApo}`;
                   </TableRow>
                 </TableBody>
               </Table>
+              
             </div>
             
   
@@ -5954,10 +5995,52 @@ export function BtnModalsPartAdd({
                         </PaginationItem>
                       </PaginationContent>
                     </Pagination>
-                    </TableCell>
-                  </TableRow>
+                  </TableCell>
+                </TableRow>
               </TableBody>
             </Table>
+
+            {/* Selected Parts Summary with Return CT Key inputs */}
+            {selectedPartCatalog.length > 0 && (
+              <div className="mt-4 p-3 border rounded-md bg-gray-50">
+                <div className="font-semibold mb-2">Selected Parts</div>
+                <Table>
+                  <TableHeader>
+                    <TableRow className="bg-gray-200">
+                      <TableHead>Part Number</TableHead>
+                      <TableHead>Description</TableHead>
+                      <TableHead>Qty</TableHead>
+                      <TableHead>Return CT Key</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {selectedPartCatalog.map((p, idx) => (
+                      <TableRow key={p.PartNumber || idx}>
+                        <TableCell>{p.PartNumber}</TableCell>
+                        <TableCell>{p.PartDescription}</TableCell>
+                        <TableCell className="max-w-24">
+                          <Input
+                            className="bg-white"
+                            value={p.qty || 1}
+                            type="number"
+                            min="1"
+                            onChange={(e) => handleQtyChangePartsCatalog(p.PartNumber, e.target.value)}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Input
+                            placeholder="Enter Return CT Key"
+                            className="bg-white"
+                            value={p.RemovedPartNumber || ''}
+                            onChange={(e) => handleRemovedPartNumberChange(p.PartNumber, e.target.value)}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
           </div>
           <DialogFooter className={'sm:justify-start'}>
             <Button 

--- a/test-vite/src/layout/Logistic_Page.jsx
+++ b/test-vite/src/layout/Logistic_Page.jsx
@@ -64,9 +64,17 @@ export default function Logistik() {
             filterStatus
         );
    
-  const totalPages = Math.ceil(filteredData.length / itemsPerPage);
+  const sortedData = [...filteredData].sort((a, b) => {
+    const orderA = a.caseinformation?.workorder?.[0]?.materialorder?.[0]?.MOID || "";
+    const orderB = b.caseinformation?.workorder?.[0]?.materialorder?.[0]?.MOID || "";
+    console.log("sorted Data", orderA)
+    console.log("sorted Data", orderB)
+    return orderB.localeCompare(orderA); // descending
+  });
+  console.log("sorted Data", sortedData)
+  const totalPages = Math.ceil(sortedData.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
-  const currentData = filteredData.slice(startIndex, startIndex + itemsPerPage);
+  const currentData = sortedData.slice(startIndex, startIndex + itemsPerPage);
 
 
     return (


### PR DESCRIPTION
# 🏯 PR: Support Multiple Material Orders Creation + Return CT Key Field

*(Dainiji Kaihō – Multi-Material Order Flow with Return CT Key)*

---

## 📜 Summary (English)

This PR introduces a **refined Material Order (MO) creation flow**, enabling **multiple MOs per part selection** and introducing **Return CT Key** support.

### 🔧 Backend Enhancements

* **ID Generation**

  * Refactored `generateID` to accept a transaction client (`tx`) for consistent ID generation within Prisma transactions.
* **`/api/service-log/create-order`**

  * Generate **multiple MOs**, one per selected part.
  * Add **per-MO case notes** and **per-MO action logs**.
  * Return `{ WOID, MOIDs, many }` instead of a single MO.
* **`/api/material-order`**

  * Support MO creation per part when linked to existing WO.
* **Data Improvements**

  * Added support for `RemovedPartNumber` (Return CT Key) in `materialorderlineitems`.

### 🎨 Frontend Enhancements

* **BtnModalsServiceCatalog & BtnModalsPartAdd**

  * Support **batch MO creation** from multiple parts.
  * Added **Return CT Key input** per selected part.
  * Part notes now log **RemovedPartNumber** (if any).
* **Logistic\_Page**

  * Sorting updated to **descending by MOID**.

### 🏯 UX/Flow Changes

* Users can now create **one MO per part** instead of bundling all into a single MO.
* Each MO is **traceable via notes and logs**.
* **CT Key (Return Key)** is now required for returned parts.

---

## 📜 Ringkasan (Bahasa Indonesia)

PR ini memperkenalkan **alur pembuatan Material Order (MO) yang lebih baik**, mendukung **banyak MO untuk setiap part** yang dipilih, serta menambahkan dukungan **Return CT Key**.

### 🔧 Perubahan Backend

* **ID Generation**

  * `generateID` kini mendukung transaksi `tx` agar konsisten dalam satu transaksi Prisma.
* **`/api/service-log/create-order`**

  * Membuat **banyak MO**, satu per part yang dipilih.
  * Tambahan **case note per-MO** dan **action log per-MO**.
  * Mengembalikan `{ WOID, MOIDs, many }` bukan hanya satu MO.
* **`/api/material-order`**

  * Mendukung pembuatan MO per part untuk WO yang sudah ada.
* **Peningkatan Data**

  * Menambahkan dukungan `RemovedPartNumber` (Return CT Key) di `materialorderlineitems`.

### 🎨 Perubahan Frontend

* **BtnModalsServiceCatalog & BtnModalsPartAdd**

  * Mendukung **pembuatan MO batch** dari beberapa part.
  * Tambahan input **Return CT Key** untuk setiap part.
  * Catatan order kini menyertakan **RemovedPartNumber** (jika ada).
* **Logistic\_Page**

  * Penyortiran diperbarui → **berdasarkan MOID descending**.

### 🏯 Perubahan UX/Flow

* User kini bisa membuat **satu MO per part**, bukan hanya 1 MO untuk semua part.
* Setiap MO dapat **ditelusuri lewat notes & logs**.
* **CT Key (Return Key)** kini tersedia untuk part yang dikembalikan.

---

## ✅ Verification Checklist

* [ ] Create Service Order with multiple parts → confirm multiple MOs are generated.
* [ ] Ensure each MO has its own **case note & action log**.
* [ ] Check UI shows **CT Key input** and persists data.
* [ ] Verify Logistic Page sorting by MOID descending.

---

⚔️ *With this, our Material Order creation system is now more disciplined, modular, and closer to the Bushido code of traceability.*

---

> ⚠️ **NOTE**  
> This is still in development, so suggest creating a new branch.  
> **Do not push to a production branch.**

