### PR TITLE
🏯 Pull Request: Refactor Warranty + Batch Update with Status Guard

### DIFF
--- a/next-api/prisma/migrations/20250924071655_adding_warranty_field/migration.sql
+++ b/next-api/prisma/migrations/20250924071655_adding_warranty_field/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE `asset_warranty` ADD COLUMN `EndUserAddress` VARCHAR(191) NULL,
+    ADD COLUMN `EndUserName` VARCHAR(191) NULL,
+    ADD COLUMN `EndUserPhone` VARCHAR(191) NULL,
+    ADD COLUMN `POPDocument` VARCHAR(191) NULL,
+    ADD COLUMN `PhotoUnit` VARCHAR(191) NULL,
+    ADD COLUMN `PurchaseDate` DATETIME(3) NULL,
+    ADD COLUMN `WarrantyApprovalStatus` VARCHAR(191) NULL,
+    ADD COLUMN `WarrantyCard` VARCHAR(191) NULL,
+    ADD COLUMN `WarrantyCardDate` DATETIME(3) NULL;

--- a/next-api/prisma/schema.prisma
+++ b/next-api/prisma/schema.prisma
@@ -30,8 +30,18 @@ model asset_information {
 }
 
 model asset_warranty {
-  WarrantyID        Int                @id @default(autoincrement())
-  AssetID           Int?
+  WarrantyID             Int       @id @default(autoincrement())
+  AssetID                Int?
+  WarrantyApprovalStatus String?
+  PurchaseDate           DateTime?
+  WarrantyCardDate       DateTime?
+  POPDocument            String?
+  WarrantyCard           String?
+  PhotoUnit              String?
+  EndUserName            String?
+  EndUserPhone           String?
+  EndUserAddress         String?
+
   asset_information asset_information? @relation(fields: [AssetID], references: [AssetID], onDelete: Restrict, onUpdate: Cascade, map: "asset_warranty_ibfk_1")
 
   @@index([AssetID], map: "AssetID")

--- a/next-api/src/app/api/case-information/route.js
+++ b/next-api/src/app/api/case-information/route.js
@@ -106,9 +106,15 @@ export async function GET(request) {
       },
       accessory: true,
       ActionLog: {
-        orderBy: {
-          ChangeAt: 'desc'
-        },
+        // where: {
+        //   CaseId: 
+        //   { 
+        //     not: null 
+        //   }
+        // },
+        // orderBy: {
+        //   ChangeAt: 'desc'
+        // },
         take: 1,
       }
     },

--- a/next-api/src/app/api/material-order/batch-update/route.js
+++ b/next-api/src/app/api/material-order/batch-update/route.js
@@ -1,155 +1,233 @@
 import { NextResponse } from "next/server";
 import prisma from "../../../../../prisma/client";
-import jwt from "jsonwebtoken";
 
-const JWT_SECRET = process.env.JWT_SECRET;
+const CASE_STATUS_BY_ORDER_STATUS = {
+  Ordered: "PartOrder",
+  Shipped: "PartAvailable",
+};
 
-export async function PATCH(request, {params}) {
-    const { updates, MOID, WOID, userId } = await request.json(); 
+export async function PATCH(request) {
+  try {
+    const {
+      updates = {},
+      MOID,
+      WOID,
+      userId,
+      SalesOrderNumber,
+      RMANumber,
+    } = await request.json();
 
-    try {
-        // const authHeader = request.headers.get("authorization");
-        // let userId = null;
-        // if (authHeader?.startsWith("Bearer ")) {
-        //     const token = authHeader.slice(7);
-        //     try {
-        //         const decoded = jwt.verify(token, JWT_SECRET);
-        //         userId = decoded?.id; // sesuaikan field di token kamu
-        //     } catch (e) {
-        //         console.warn("JWT invalid:", e.message);
-        //     }
-        // }
-
-        let oldOrderStatus = null;
-        let newOrderStatus = null;
-
-        
-        await prisma.$transaction(async (tx) => {
-        
-            const oldMO = await tx.materialorder.findUnique({ where: { MOID } });
-            oldOrderStatus = oldMO?.OrderStatus;
-
-            // update line items
-            for (const [lineItemID, newStatus] of Object.entries(updates)) {
-                await tx.materialorderlineitems.update({
-                    where: { LineItemID: Number(lineItemID) },
-                    data: { Status: newStatus },
-                });
-            }
-
-        // cek apakah semua MOLI sudah shipped
-        const allItems = await tx.materialorderlineitems.findMany({ where: { MOID } });
-        const allShipped = allItems.every((item) => item.Status === "Shipped");
-        const allOrdered = allItems.every((item) => item.Status === "Ordered");
-        const allCancelled = allItems.every((item) => item.Status === "Cancelled");
-
-        if (allShipped) {
-            await tx.materialorder.update({
-                where: { MOID },
-                data: { OrderStatus: "Shipped" },
-            });
-        }
-
-        if (allOrdered) {
-        await tx.materialorder.update({
-            where: { MOID },
-            data: { OrderStatus: "Ordered" },
-        });
-        }
-
-        if (allCancelled) {
-        await tx.materialorder.update({
-            where: { MOID },
-            data: { OrderStatus: "Cancelled" },
-        });
-        }
-        
-        const getWOID = await prisma.workorder.findUnique({
-            where: { WOID},
-            include: {
-                caseinformation: true
-            }
-        })
-        console.log(getWOID)
-        //action log terkait MOID
-        await tx.actionLog.create({
-            data: {
-                CaseId: getWOID?.caseinformation?.CaseID,
-                ReferenceId: MOID,
-                model: "Material Orders",
-                dataOld: oldOrderStatus ?? "Unknown",
-                dataNew: "Ordered",
-                changedBy: userId,
-                logDescription: `Batch update MOLI for MO ${MOID}: ${Object.keys(updates).length} item(s) updated. MO status: ${oldOrderStatus} → Ordered`,
-            },
-        });
-
-        await tx.actionLog.create({
-            data: {
-                CaseId: getWOID?.caseinformation?.CaseID,
-                ReferenceId: MOID,
-                model: "Material Orders",
-                dataOld: oldOrderStatus ?? "Unknown",
-                dataNew: "Shipped",
-                changedBy: userId,
-                logDescription: `Batch update MOLI for MO ${MOID}: ${Object.keys(updates).length} item(s) updated. MO status: ${oldOrderStatus} → Shipped`,
-            },
-        });
-
-        await tx.actionLog.create({
-            data: {
-                CaseId: getWOID?.caseinformation?.CaseID,
-                ReferenceId: MOID,
-                model: "Material Orders",
-                dataOld: oldOrderStatus ?? "Unknown",
-                dataNew: "Cancelled",
-                changedBy: userId,
-                logDescription: `Batch update MOLI for MO ${MOID}: ${Object.keys(updates).length} item(s) updated. MO status: ${oldOrderStatus} → Shipped`,
-            },
-        });
-
-        //action log case
-        await tx.actionLog.create({
-            data: {
-                CaseId: `${getWOID?.caseinformation?.CaseID}`,
-                model: "Case",
-                dataOld: getWOID?.caseinformation?.CaseStatus,
-                dataNew: "Part Available",
-                changedBy: userId,
-                logDescription: `Edit: change status from ${getWOID?.caseinformation?.CaseStatus} to Part Available`
-            }
-        })
-        //pergantian case status ke part avilable
-        await tx.caseinformation.update({
-            where: { 
-                CaseID: getWOID?.caseinformation.CaseID
-            },
-            data: {
-                CaseStatus: "PartAvailable",
-                Owner: getWOID?.OwnerID
-            }
-        })
-        
-        
-    });
-    const updatedMO = await prisma.materialorder.findUnique({
-        where: { MOID },
-        include: { materialorderlineitems: true },
-    });
-    return NextResponse.json(
+    if (!MOID || !WOID) {
+      return NextResponse.json(
         {
-            success: true,
-            message: "Batch update success!",
-            data: updatedMO,
+          success: false,
+          message: "MOID and WOID are required for batch update",
         },
-        { status: 200 }
-    );
-    
-    } catch (error) {
-        return NextResponse.json({
-            success: false,
-            message: "Failed to update Batch Material Order",
-            error: error.message
-        }, { status: 500 });
+        { status: 400 },
+      );
     }
+
+    const result = await prisma.$transaction(async (tx) => {
+      const [materialOrder, workOrder] = await Promise.all([
+        tx.materialorder.findUnique({ where: { MOID } }),
+        tx.workorder.findUnique({
+          where: { WOID },
+          include: { caseinformation: true },
+        }),
+      ]);
+
+      if (!materialOrder) {
+        throw new Error("Material Order not found");
+      }
+
+      if (!workOrder) {
+        throw new Error("Work Order not found");
+      }
+
+      const originalOrderStatus = materialOrder.OrderStatus;
+      const originalSalesOrder = materialOrder.SalesOrderNumber ?? null;
+      const originalRmaNumber = materialOrder.RMANumber ?? null;
+
+      const updateEntries = Object.entries(updates ?? {});
+      if (updateEntries.length > 0) {
+        for (const [lineItemID, status] of updateEntries) {
+          await tx.materialorderlineitems.update({
+            where: { LineItemID: Number(lineItemID) },
+            data: { Status: status },
+          });
+        }
+      }
+
+      const lineItems = await tx.materialorderlineitems.findMany({ where: { MOID } });
+      const allMatch = (status) =>
+        lineItems.length > 0 && lineItems.every((item) => item.Status === status);
+
+      const materialOrderUpdate = {};
+
+      if (allMatch("Shipped")) {
+        materialOrderUpdate.OrderStatus = "Shipped";
+      } else if (allMatch("Ordered")) {
+        materialOrderUpdate.OrderStatus = "Ordered";
+      } else if (allMatch("Cancelled")) {
+        materialOrderUpdate.OrderStatus = "Cancelled";
+      } else if (allMatch("Closed")) {
+        materialOrderUpdate.OrderStatus = "Closed";
+      } else if (allMatch("Submitted")) {
+        materialOrderUpdate.OrderStatus = "Submitted";
+      } else if (allMatch("New")) {
+        materialOrderUpdate.OrderStatus = "New";
+      }
+
+      if (
+        SalesOrderNumber !== undefined &&
+        (SalesOrderNumber || null) !== originalSalesOrder
+      ) {
+        materialOrderUpdate.SalesOrderNumber = SalesOrderNumber || null;
+      }
+
+      if (
+        RMANumber !== undefined &&
+        (RMANumber || null) !== originalRmaNumber
+      ) {
+        materialOrderUpdate.RMANumber = RMANumber || null;
+      }
+
+      let updatedOrder = materialOrder;
+      if (Object.keys(materialOrderUpdate).length > 0) {
+        updatedOrder = await tx.materialorder.update({
+          where: { MOID },
+          data: materialOrderUpdate,
+        });
+      }
+
+      const derivedOrderStatus = updatedOrder.OrderStatus;
+      const logsToCreate = [];
+
+      if (updateEntries.length > 0) {
+        const statusSummary =
+          derivedOrderStatus !== originalOrderStatus
+            ? `${originalOrderStatus ?? "Unknown"} -> ${derivedOrderStatus}`
+            : derivedOrderStatus ?? originalOrderStatus ?? "Unknown";
+
+        logsToCreate.push({
+          CaseId: workOrder.caseinformation?.CaseID,
+          ReferenceId: MOID,
+          model: "Material Orders",
+          dataOld: originalOrderStatus ?? "Unknown",
+          dataNew: derivedOrderStatus ?? originalOrderStatus ?? "Unknown",
+          changedBy: userId,
+          logDescription: `Batch update MOLI for MO ${MOID}: ${updateEntries.length} item(s) updated. MO status: ${statusSummary}`,
+        });
+      }
+
+      const targetCaseStatus = CASE_STATUS_BY_ORDER_STATUS[derivedOrderStatus];
+      const currentCaseStatus = workOrder.caseinformation?.CaseStatus ?? null;
+
+      let caseOwnerId = null;
+      if (targetCaseStatus === "PartOrder") {
+        let logisticUser = await tx.user.findUnique({ where: { Username: "logis" } });
+        if (!logisticUser) {
+          logisticUser = await tx.user.findFirst({
+            where: { Role: { equals: "lg", mode: "insensitive" } },
+            orderBy: { IDUser: "asc" },
+          });
+        }
+        caseOwnerId = logisticUser?.IDUser ?? null;
+      } else if (targetCaseStatus === "PartAvailable") {
+        caseOwnerId = workOrder.OwnerID ?? null;
+      }
+
+      if (
+        targetCaseStatus &&
+        targetCaseStatus !== currentCaseStatus &&
+        workOrder.caseinformation?.CaseID
+      ) {
+        const caseUpdateData = {
+          CaseStatus: targetCaseStatus,
+        };
+        if (caseOwnerId) {
+          caseUpdateData.Owner = caseOwnerId;
+        }
+
+        await tx.caseinformation.update({
+          where: { CaseID: workOrder.caseinformation.CaseID },
+          data: caseUpdateData,
+        });
+
+        const ownerChanged =
+          caseOwnerId &&
+          caseOwnerId !== (workOrder.caseinformation?.Owner ?? null);
+
+        const ownerNote = ownerChanged
+          ? targetCaseStatus === "PartOrder"
+            ? " Owner reassigned to Logistic."
+            : " Owner reassigned to CE."
+          : "";
+
+        logsToCreate.push({
+          CaseId: `${workOrder.caseinformation.CaseID}`,
+          model: "Case",
+          dataOld: currentCaseStatus ?? "Unknown",
+          dataNew: targetCaseStatus,
+          changedBy: userId,
+          logDescription: `Edit: change status from ${currentCaseStatus ?? "Unknown"} to ${targetCaseStatus}.${ownerNote}`,
+        });
+      }
+
+      const identifiersChanged =
+        (SalesOrderNumber !== undefined && (SalesOrderNumber || null) !== originalSalesOrder) ||
+        (RMANumber !== undefined && (RMANumber || null) !== originalRmaNumber);
+
+      if (identifiersChanged && updateEntries.length === 0) {
+        const changes = [];
+        if (SalesOrderNumber !== undefined && (SalesOrderNumber || null) !== originalSalesOrder) {
+          changes.push(`SO: ${originalSalesOrder ?? "-"} -> ${SalesOrderNumber || "-"}`);
+        }
+        if (RMANumber !== undefined && (RMANumber || null) !== originalRmaNumber) {
+          changes.push(`RMA: ${originalRmaNumber ?? "-"} -> ${RMANumber || "-"}`);
+        }
+
+        logsToCreate.push({
+          CaseId: workOrder.caseinformation?.CaseID,
+          ReferenceId: MOID,
+          model: "Material Orders",
+          dataOld: originalOrderStatus ?? "Unknown",
+          dataNew: derivedOrderStatus ?? originalOrderStatus ?? "Unknown",
+          changedBy: userId,
+          logDescription: `Material Order ${MOID} identifiers updated (${changes.join(", ")})`,
+        });
+      }
+
+      for (const log of logsToCreate) {
+        await tx.actionLog.create({ data: log });
+      }
+
+      const updatedLineItems = await tx.materialorderlineitems.findMany({ where: { MOID } });
+
+      return {
+        materialOrder: {
+          ...updatedOrder,
+          materialorderlineitems: updatedLineItems,
+        },
+      };
+    });
+
+    return NextResponse.json(
+      {
+        success: true,
+        message: "Batch update success!",
+        data: result.materialOrder,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        message: "Failed to update Batch Material Order",
+        error: error.message,
+      },
+      { status: 500 },
+    );
+  }
 }

--- a/test-vite/src/components/model/sc-modal.jsx
+++ b/test-vite/src/components/model/sc-modal.jsx
@@ -4994,8 +4994,9 @@ export function BtnModalsServiceCatalog({
     assetForWorkOrderCreation?.AssetInformation?.WarrantyOTCCode?.WarrantyCondition;
 
   const isOutWarranty =
-    assetForWorkOrderCreation?.AssetInformation?.WarrantyOTCCode?.OTCCode === "01T";
-
+    assetForWorkOrderCreation?.Warranty_Status === "01T";
+console.log("Asset Info OTC : ",isOutWarranty)
+    
   const filteredWarrantyOffers = warrantyOffer.filter(
     (service) =>
       isOutWarranty

--- a/test-vite/src/pages/CaseDetail.jsx
+++ b/test-vite/src/pages/CaseDetail.jsx
@@ -1348,9 +1348,6 @@ let canEdit;
 let canEditFd;
 let canEditApo;
 
-let canEdit;
-let canEditFd;
-let canEditApo;
 const [hideAsignTo, setHideAsignTo] = useState(null)
 if (caseDetails.CaseStatus !== "Close") {
    canEdit = caseDetails?.Owner === user?.id;

--- a/test-vite/src/pages/CaseDetail.jsx
+++ b/test-vite/src/pages/CaseDetail.jsx
@@ -1337,6 +1337,9 @@ const fetchSymptomCodes = async (term) => {
   }
 };
 
+let canEdit;
+let canEditFd;
+let canEditApo;
 const [hideAsignTo, setHideAsignTo] = useState(null)
 if (caseDetails.CaseStatus !== "Close") {
    canEdit = caseDetails?.Owner === user?.id;

--- a/test-vite/src/pages/CaseDetail.jsx
+++ b/test-vite/src/pages/CaseDetail.jsx
@@ -1338,10 +1338,44 @@ const fetchSymptomCodes = async (term) => {
 };
 
 const [hideAsignTo, setHideAsignTo] = useState(null)
-  const canEdit = caseDetails?.Owner === user?.id;
-  const canEditFd = user?.role === "fd" ;
-  const canEditApo = user?.role === "apo" ;
-  
+if (caseDetails.CaseStatus !== "Close") {
+   canEdit = caseDetails?.Owner === user?.id;
+   canEditFd = user?.role === "fd" ;
+   canEditApo = user?.role === "apo" ;
+} else {
+   canEdit = false;
+   canEditFd = false;
+   canEditApo = false;
+}
+
+
+
+  // ----------------------------
+  // Photo handlers
+  // ----------------------------
+
+  // Photos
+  /** @type {[File[], (val: File[]) => void]} */
+  const [photos, setPhotos] = useState([]);
+  /**
+   * Handle file input change for photos.
+   * @param {FileList|null} files
+   */
+  const onPickPhotos = (files) => {
+    if (!files) return;
+    const validFiles = Array.from(files).filter((f) => {
+      if (f.size > 5 * 1024 * 1024) {
+        toast.warning(`${f.name} lebih dari 5MB, tidak bisa diupload`);
+        return false;
+      }
+      if (!f.type.startsWith("image/")) {
+        toast.warning(`${f.name} bukan file gambar`);
+        return false;
+      }
+      return true;
+    });
+    setPhotos(validFiles);
+  };
   return (
     <>
       {caseDetails.CaseStatus === "Close" && (
@@ -2320,12 +2354,72 @@ const [hideAsignTo, setHideAsignTo] = useState(null)
                   <CardHeader>
                   <CardTitle className={"text-lg"}>Photo Unit</CardTitle>
                   <hr />
+                  {/* Tombol Add Photo */}
+                  <div className="flex items-center gap-2">
+                    <Input 
+                      type="file" 
+                      multiple 
+                      accept="image/*" 
+                      className="hidden" 
+                      id="upload-photos" 
+                      onChange={(e) => onPickPhotos(e.target.files)} 
+                    />
+                    <label htmlFor="upload-photos">
+                      <Button asChild size="sm" variant="outline">
+                        <span>+ Add Photo</span>
+                      </Button>
+                    </label>
+                    {photos.length > 0 && (
+                      <Button
+                        size="sm"
+                        onClick={async () => {
+                          try {
+                            const fd = new FormData();
+                            photos.forEach((f) => fd.append("files", f));
+                            fd.append("caseId", caseDetails.CaseID); // pastikan sesuai field caseId
+                            await ApiCustomer.post("/api/case-information/upload-case", fd, {
+                              headers: { "Content-Type": "multipart/form-data" },
+                            });
+                            toast.success("Photos uploaded!");
+                            setPhotos([]); // reset preview
+                            // optionally: refresh caseDetails setelah upload
+                          } catch (e) {
+                            toast.error("Photo upload failed");
+                          }
+                        }}
+                      >
+                        Upload Photos
+                      </Button>
+                    )}
+                  </div>
+
                 </CardHeader>
                 <CardContent className={"grid grid-cols-2 gap-3"}>
+                  {/* preview photos baru sebelum upload */}
+                  <p>PREVIEW</p>
+                  {photos.length > 0 && photos.map((file, idx) => (
+                    <div key={idx} className="relative">
+                      
+                      <img
+                        src={URL.createObjectURL(file)}
+                        alt={file.name}
+                        className="w-full h-full object-cover rounded-lg border"
+                      />
+                      <p className="text-xs truncate mt-1">{file.name}</p>
+                    </div>
+                  ))}
+               </CardContent>
+               <hr />
                   {caseDetails.casephotos.map(photo =>(
                     <img src={import.meta.env.VITE_API_BASE_URL +''+photo.url} alt="" className="w-full border-4 border-white shadow-lg object-cover"/>
                   ))}
-               </CardContent>
+
+               {photos.length > 0 && (
+                  <CardFooter>
+                    
+                  </CardFooter>
+                )}
+
                   </Card>
                 </div>
           </TabsContent>

--- a/test-vite/src/pages/services/service-booking.jsx
+++ b/test-vite/src/pages/services/service-booking.jsx
@@ -889,19 +889,19 @@ export function NewBookableResourceBooking({ CaseID, WOID, CreatedBy, RequestedD
 
       const response = await ApiCustomer.post('/api/bookings', data);
       //update case
-      const updateCaseStatus = await ApiCustomer.patch(`/api/case-information/${CaseID}`, {
-        CaseStatus: "PartOrder",
-        Owner: selectedLogistic.IDUser
-      })
+      // const updateCaseStatus = await ApiCustomer.patch(`/api/case-information/${CaseID}`, {
+      //   CaseStatus: "PartOrder",
+      //   Owner: selectedLogistic.IDUser
+      // })
 
-      const updateLogCase = await ApiCustomer.post("/api/actionlog",{
-        CaseId: `${caseDetails.CaseID}`,
-        model: "Case",
-        dataOld: caseDetails.CaseStatus,
-        dataNew: "PartOrder",
-        changedBy: data.user.id,
-        logDescription: `Edit: change status from ${caseDetails.CaseStatus} to PartOrder`
-      })
+      // const updateLogCase = await ApiCustomer.post("/api/actionlog",{
+      //   CaseId: `${caseDetails.CaseID}`,
+      //   model: "Case",
+      //   dataOld: caseDetails.CaseStatus,
+      //   dataNew: "PartOrder",
+      //   changedBy: data.user.id,
+      //   logDescription: `Edit: change status from ${caseDetails.CaseStatus} to PartOrder`
+      // })
       const updateWorkLog = await ApiCustomer.post("/api/actionlog",{
         CaseId: `${CaseID}`,
         ReferenceId: `${data.WOID}`,

--- a/test-vite/src/pages/services/service-case.jsx
+++ b/test-vite/src/pages/services/service-case.jsx
@@ -944,7 +944,7 @@ export const TabsServiceMO = ({ materialOrders, updatedLineItems, moForm }) => {
       let res = null;
       // Guard: if any line item update is set to Shipped, require SON and RMA
       const hasShippingUpdate = updatedLineItems && Object.values(updatedLineItems).some(
-        (v) => String(v).toLowerCase() === 'shipped' || String(v).toLowerCase() === 'Ordered'
+        (v) => String(v).toLowerCase() === 'shipped' || String(v).toLowerCase() === 'ordered'
       );
       const soNumber = (moForm?.SalesOrderNumber ?? materialOrders?.SalesOrderNumber ?? '').toString().trim();
       const rmaNumber = (moForm?.RMANumber ?? materialOrders?.RMANumber ?? '').toString().trim();
@@ -956,25 +956,23 @@ export const TabsServiceMO = ({ materialOrders, updatedLineItems, moForm }) => {
           text: 'Before setting a line item to Shipped, fill Sales Order Number and RMA Number.',
         });
       }
-      if(updatedLineItems === null || Object.keys(updatedLineItems).length === 0) {
-        const result = await ApiCustomer.patch(`/api/material-order/${materialOrders.MOID}`,{
-          SalesOrderNumber: moForm.SalesOrderNumber || undefined,
-          RMANumber: moForm.RMANumber || undefined,
-        })
+      if (!updatedLineItems || Object.keys(updatedLineItems).length === 0) {
+        const result = await ApiCustomer.patch(`/api/material-order/${materialOrders.MOID}`, {
+          SalesOrderNumber: soNumber || undefined,
+          RMANumber: rmaNumber || undefined,
+        });
         res = result;
-      }else{
-        for(const [lineItemID, status] of Object.entries(updatedLineItems)){
-          console.log("user", user);
-          const result = await ApiCustomer.patch(`/api/material-order/batch-update`, {
-            updates: updatedLineItems,
-            MOID: materialOrders.MOID,
-            WOID: materialOrders.WOID,
-            userId: user.id
-          })
-          console.log("update ok",updatedLineItems);
-          res = result;
-        }
-
+      } else {
+        const payload = {
+          updates: updatedLineItems,
+          MOID: materialOrders.MOID,
+          WOID: materialOrders.WOID,
+          userId: user.id,
+          SalesOrderNumber: soNumber || null,
+          RMANumber: rmaNumber || null,
+        };
+        const result = await ApiCustomer.patch(`/api/material-order/batch-update`, payload);
+        res = result;
       }
       console.log("RES : ",res);
       if(res.data) {


### PR DESCRIPTION
# 🏯 Pull Request: Refactor Warranty + Batch Update with Status Guard

The way of the code is like the way of the samurai — every line must serve its duty with honor and precision.
This PR sharpens our blade by extending the **warranty system**, empowering **photo uploads**, and fortifying the **material order batch update** with discipline.

---

## 🌸 New Additions: Warranty Expansion & CaseDetail Uploads

* Extended `asset_warranty` model with new fields:

  * `EndUserName`, `EndUserAddress`, `EndUserPhone`
  * `PurchaseDate`, `WarrantyCard`, `WarrantyCardDate`
  * `WarrantyApprovalStatus`, `POPDocument`, `PhotoUnit`
* Enabled **photo upload** in `CaseDetail.jsx` with:

  * Validation checks
  * Preview before submission
* Ensured backend paths (`/public/images/conditions`, `/public/images/uploads`) must exist — like a dojo prepared before training.

---

## ⚔️ Refined Discipline: Batch Update & Status Guard

* **Status-mapping guard**: Case status now shifts only when transitions are honorable (e.g., Ordered → PartOrder, Shipped → PartAvailable).
* **Unified transaction**: Sales & RMA updates now happen as one, ensuring consistency.
* **Owner sync**:

  * `PartOrder` → assigned to Logistics (User = `logis` or first `lg`)
  * `PartAvailable` → reassigned to Work Order owner (`CE`)
* **Single accurate action log**: Covers both case + material order updates, like one ink stroke on parchment.
* **Shipping status fixed**: Corrected ordered comparison.
* **Sales/RMA values**: Trimmed, reused, and saved only when changed.

---

## 🐛 Fixes Issue #108   : Status Switching & Batch Update

### Problem

* Status forcibly jumped to `PartAvailable`, ignoring proper flow.
* Batch update failed to save **Sales Order**.

### Resolution

* Refactored status switch with strict **from → to** validation.
* Fixed batch update condition so **SO** is always saved.

---

## 📜 Indonesian Translation

### 🌸 Penambahan Baru: Perluasan Warranty & Upload Foto di CaseDetail

* Model `asset_warranty` diperluas dengan field baru:

  * `EndUserName`, `EndUserAddress`, `EndUserPhone`
  * `PurchaseDate`, `WarrantyCard`, `WarrantyCardDate`
  * `WarrantyApprovalStatus`, `POPDocument`, `PhotoUnit`
* **Upload foto** di `CaseDetail.jsx` dengan:

  * Validasi data
  * Preview sebelum submit
* Pastikan folder backend (`/public/images/conditions`, `/public/images/uploads`) dibuat agar upload berhasil.

---

### ⚔️ Penyempurnaan: Batch Update & Status Guard

* **Status guard**: Status case hanya berpindah jika sesuai aturan (contoh: Ordered → PartOrder, Shipped → PartAvailable).
* **Transaksi tunggal**: Update Sales & RMA dilakukan dalam satu transaksi agar konsisten.
* **Sinkronisasi owner**:

  * `PartOrder` → ditugaskan ke Logistics (`logis` atau user role `lg`)
  * `PartAvailable` → kembali ke owner WO (`CE`)
* **Log aksi tunggal**: Mencatat perubahan case + material order sekaligus.
* **Perbaikan status shipping**: Koreksi pada pengecekan status ordered.
* **Nilai Sales/RMA**: Disimpan hanya jika ada perubahan.

---

### 🐛 Perbaikan Isu #108 

**Masalah**

* Status langsung lompat ke `PartAvailable`, tidak mengikuti flow yang benar.
* Batch update gagal menyimpan **Sales Order**.

**Solusi**

* Refactor logika status agar validasi dari → ke lebih ketat.
* Memperbaiki kondisi batch update supaya **SO** selalu tersimpan.

