### PR TITLE
⚠️ Issue Report: Dual State Handling in `service-materialApo.jsx` – *MoForm vs materialOrderInformation*

### DIFF
--- a/next-api/src/app/api/material-order/[MOID]/route.js
+++ b/next-api/src/app/api/material-order/[MOID]/route.js
@@ -93,7 +93,7 @@ export async function PATCH(request, { params }) {
       accidentalDamageProtection: AccidentalDamageProtection,
       defectiveMediaRetention: DefectiveMediaRetention,
       notificationNumber: NotificationNumber,
-      salesOrderNumber: SalesOrderNumber,
+      SalesOrderNumber,
       parentMO: ParentMOID,
       isBCPOrder: IsBCPOrder,
       materialOrderType: MaterialOrderType,
@@ -101,11 +101,13 @@ export async function PATCH(request, { params }) {
       ownerID: OwnerID,
       createdOn: CreatedOn,
       orderStatus: OrderStatus,
-      rmaNumber: RMANumber,
+      RMANumber,
       AWB_InCode,
       AWB_OutCode,
       RMAStatus
     } = moUpdates;
+
+    
 
     const existingMaterialOrder = await prisma.materialorder.findUnique({
       where: { MOID: moid },

--- a/next-api/src/app/api/material-order/[MOID]/route.js
+++ b/next-api/src/app/api/material-order/[MOID]/route.js
@@ -107,7 +107,7 @@ export async function PATCH(request, { params }) {
       RMAStatus
     } = moUpdates;
 
-    
+    // return console.log("MOUPDATES : ",moUpdates,"\n")
 
     const existingMaterialOrder = await prisma.materialorder.findUnique({
       where: { MOID: moid },

--- a/test-vite/src/pages/SearchCase_V3.jsx
+++ b/test-vite/src/pages/SearchCase_V3.jsx
@@ -333,7 +333,7 @@ export default function NewCaseForm() {
   const [companyAddressLine1, setCompanyAddressLine1] = useState("");
   const [companyStateProvince, setCompanyStateProvince] = useState("");
   const [companyCity, setCompanyCity] = useState("");
-  const [companyCountry, setCompanyCountry] = useState("");
+  const [companyCountry, setCompanyCountry] = useState("Indonesia");
   const [companyZipPostalCode, setCompanyZipPostalCode] = useState("");
   const [companyNPWP, setCompanyNPWP] = useState("");
 
@@ -1749,6 +1749,7 @@ export default function NewCaseForm() {
                       <Label className="col-span-1">Country<Label className="text-red-600">*</Label></Label>
                       <Input className="col-span-2" value={companyCountry} onChange={(e) => setCompanyCountry(e.target.value)} />
                     </div>
+                    {companyCountry.toLowerCase() === 'indonesia' ? (
                     <div className="grid grid-cols-3 gap-2 items-center">
                       <Label className="col-span-1">Province (ID)<Label className="text-red-600">*</Label></Label>
                       <div className="col-span-2">
@@ -1768,25 +1769,53 @@ export default function NewCaseForm() {
                         />
                       </div>
                     </div>
-                    <div className="grid grid-cols-3 gap-2 items-center">
-                      <Label className="col-span-1">City (ID)<Label className="text-red-600">*</Label></Label>
-                      <div className="col-span-2">
-                        {/* <SelectBarState
-                          id="CompanyCity"
-                          value={companyCity}
-                          onChange={setCompanyCity}
-                          options={cityCompany}
-                          placeholder="Select a City"
-                        /> */}
-                        <ComboboxDemo
-                          id="CompanyCity"
-                          value={companyCity}
-                          setValue={setCompanyCity}
-                          options={cityCompany}
-                          placeholder="Select a City"
+                    ) : (
+                      <div className="grid grid-cols-3 gap-2 items-center">
+                        <Label className="col-span-1">
+                          State / Region<Label className="text-red-600">*</Label>
+                        </Label>
+                        <Input
+                          className="col-span-2"
+                          value={companyStateProvince}
+                          onChange={(e) => setCompanyStateProvince(e.target.value)}
+                          placeholder="e.g. Tokyo, California, etc."
                         />
                       </div>
-                    </div>
+                    )}
+
+                    {companyCountry.toLowerCase() === "indonesia" ? (
+                      <div className="grid grid-cols-3 gap-2 items-center">
+                        <Label className="col-span-1">City (ID)<Label className="text-red-600">*</Label></Label>
+                        <div className="col-span-2">
+                          {/* <SelectBarState
+                            id="CompanyCity"
+                            value={companyCity}
+                            onChange={setCompanyCity}
+                            options={cityCompany}
+                            placeholder="Select a City"
+                          /> */}
+                          <ComboboxDemo
+                            id="CompanyCity"
+                            value={companyCity}
+                            setValue={setCompanyCity}
+                            options={cityCompany}
+                            placeholder="Select a City"
+                          />
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="grid grid-cols-3 gap-2 items-center">
+                        <Label className="col-span-1">
+                          City / Area<Label className="text-red-600">*</Label>
+                        </Label>
+                        <Input
+                          className="col-span-2"
+                          value={companyCity}
+                          onChange={(e) => setCompanyCity(e.target.value)}
+                          placeholder="e.g. Jakarta, Berlin, New York..."
+                        />
+                      </div>
+                    )}
                     <div className="grid grid-cols-3 gap-2 items-center">
                       <Label className="col-span-1">Zip Code<Label className="text-red-600">*</Label></Label>
                       <Input className="col-span-2" value={companyZipPostalCode} onChange={(e) => setCompanyZipPostalCode(e.target.value)} />

--- a/test-vite/src/pages/services/service-case.jsx
+++ b/test-vite/src/pages/services/service-case.jsx
@@ -990,8 +990,9 @@ export const TabsServiceMO = ({ materialOrders, updatedLineItems, moForm, setMoF
       const hasShippingUpdate = updatedLineItems && Object.values(updatedLineItems).some(
         (v) => String(v).toLowerCase() === 'shipped' || String(v).toLowerCase() === 'ordered'
       );
-      const soNumber = (moForm?.SalesOrderNumber ?? materialOrders?.SalesOrderNumber ?? '').toString().trim();
-      const rmaNumber = (moForm?.RMANumber ?? materialOrders?.RMANumber ?? '').toString().trim();
+      const soNumber = (moForm?.SalesOrderNumber ?? materialOrderInformation?.SalesOrderNumber ?? materialOrders?.SalesOrderNumber ?? '').toString().trim();
+      const rmaNumber = (moForm?.RMANumber ?? materialOrderInformation?.RMANumber ?? materialOrders?.RMANumber ?? '').toString().trim();
+      // return console.log(soNumber, moForm, materialOrderInformation);
       if (hasShippingUpdate && (!soNumber || !rmaNumber)) {
         Swal.close();
         return Swal.fire({

--- a/test-vite/src/pages/services/service-materialApo.jsx
+++ b/test-vite/src/pages/services/service-materialApo.jsx
@@ -59,6 +59,11 @@ export const ServiceMaterialApo = () => {
   const [materialOrders, setMaterialOrders] = useState([]);
   const [materialLineOrders, setMaterialLineOrders] = useState([]);
   const [MaterialOrder, setMaterialOrder] = useState([]);
+  /**
+   * TODO (WARNING ISSUES) 
+   * REMOVE MO FORM, USE STATE DEFINED ONE. 
+   * this will also change the handle Save Function.
+   */
   const [moForm, setMoForm] = useState({
     SalesOrderNumber: "",
     RMANumber: "",
@@ -80,7 +85,7 @@ export const ServiceMaterialApo = () => {
     accidentalDamageProtection: false,
     defectiveMediaRetention: false,
     notificationNumber: "",
-    salesOrderNumber: "",
+    SalesOrderNumber: "",
     resourceName: "",
     resourceId: "",
     workOrder: null,
@@ -91,6 +96,8 @@ export const ServiceMaterialApo = () => {
     AWB_InCode: "",
     AWB_OutCode: "",
     RMAStatus: null,
+    SalesOrderNumber: "",
+    RMANumber: "",
   });
   // const [collectionRequestedDate, setCollectionRequestedDate] = useState(null);
   // const [readyForClosureDate, setReadyForClosureDate] = useState(null);
@@ -283,16 +290,26 @@ export const ServiceMaterialApo = () => {
   // }
 
   useEffect(() => {
-    console.log("lo",moForm.SalesOrderNumber)
     setMoForm({
       ...moForm,
       RMANumber: moForm.SalesOrderNumber
     })
     setMaterialOrderInformation({
       ...materialOrderInformation,
+      SalesOrderNumber: moForm.SalesOrderNumber,
       RMANumber: moForm.SalesOrderNumber
     })
   },[moForm.SalesOrderNumber])
+
+  /**
+   * TODO : REMOVE THIS LATER IF THE MOFORM IS REMOVED
+   */
+  useEffect(() =>{
+    setMaterialOrderInformation({
+      ...materialOrderInformation,
+      RMANumber: moForm.RMANumber
+    })
+  },[moForm.RMANumber])
   
   return (
     <div>

--- a/test-vite/src/pages/services/service-materialApo.jsx
+++ b/test-vite/src/pages/services/service-materialApo.jsx
@@ -96,7 +96,6 @@ export const ServiceMaterialApo = () => {
     AWB_InCode: "",
     AWB_OutCode: "",
     RMAStatus: null,
-    SalesOrderNumber: "",
     RMANumber: "",
   });
   // const [collectionRequestedDate, setCollectionRequestedDate] = useState(null);
@@ -188,7 +187,7 @@ export const ServiceMaterialApo = () => {
         accidentalDamageProtection: data.AccidentalDamageProtection || false,
         defectiveMediaRetention: data.DefectiveMediaRetention || false,
         notificationNumber: data.NotificationNumber || "",
-        salesOrderNumber: data.SalesOrderNumber || "",
+        SalesOrderNumber: data.SalesOrderNumber || "",
         resourceName: data.Resource?.Name || "",
         resourceId: data.Resource?.ResourceId || "",
         workOrder: data.WOID || null,
@@ -290,25 +289,26 @@ export const ServiceMaterialApo = () => {
   // }
 
   useEffect(() => {
-    setMoForm({
-      ...moForm,
-      RMANumber: moForm.SalesOrderNumber
-    })
-    setMaterialOrderInformation({
-      ...materialOrderInformation,
+    // setMoForm({
+    //   ...moForm,
+    //   RMANumber: moForm.SalesOrderNumber
+    // })
+    console.log("TEST MO FORM : ", moForm.SalesOrderNumber, materialOrderInformation.SalesOrderNumber)
+    setMaterialOrderInformation(prev => ({
+      ...prev,
       SalesOrderNumber: moForm.SalesOrderNumber,
-      RMANumber: moForm.SalesOrderNumber
-    })
+      // RMANumber: moForm.SalesOrderNumber
+    }))
   },[moForm.SalesOrderNumber])
 
   /**
    * TODO : REMOVE THIS LATER IF THE MOFORM IS REMOVED
    */
   useEffect(() =>{
-    setMaterialOrderInformation({
-      ...materialOrderInformation,
+    setMaterialOrderInformation(prev => ({
+      ...prev,
       RMANumber: moForm.RMANumber
-    })
+    }))
   },[moForm.RMANumber])
   
   return (
@@ -436,7 +436,11 @@ export const ServiceMaterialApo = () => {
                       type="text"
                       value={moForm?.SalesOrderNumber || ""}
                       placeholder="---"
-                      onChange={handleMoFormChange("SalesOrderNumber")}
+                      onChange={(e) => {
+                        const val = e.target.value
+                        handleMoFormChange("SalesOrderNumber")(e)
+                        handleMoFormChange("RMANumber")(e)
+                      }}
                     />
                   </CaseField>
 


### PR DESCRIPTION
## ⚠️ Issue Report: Dual State Handling in `service-materialApo.jsx` – *MoForm vs materialOrderInformation*

### 🗂️ Affected File:

`service-materialApo.jsx`

### 📌 Summary:

A duplicated state structure (`moForm`) exists alongside the main `materialOrderInformation` state. This redundancy introduces risk and unnecessary complexity in state handling, especially when dealing with fields like `SalesOrderNumber` and `RMANumber`.

---

### 🧾 Description:

Currently, there are two separate state declarations managing overlapping data fields:

```js
const [moForm, setMoForm] = useState({
  SalesOrderNumber: "",
  RMANumber: "",
});
```

```js
const [materialOrderInformation, setMaterialOrderInformation] = useState({
  ...
  SalesOrderNumber: "",
  RMANumber: "",
  ...
});
```

This dual handling leads to inconsistencies in user input and logic branching within `saveMaterialOrder()`, requiring conditional prioritization (`moForm` OR `materialOrders`) for critical data like Sales Order and RMA numbers.

Furthermore, temporary synchronization was applied using `useEffect`:

```js
useEffect(() => {
  setMoForm({ ...moForm, RMANumber: moForm.SalesOrderNumber });
  setMaterialOrderInformation({
    ...materialOrderInformation,
    SalesOrderNumber: moForm.SalesOrderNumber,
    RMANumber: moForm.SalesOrderNumber,
  });
}, [moForm.SalesOrderNumber]);

useEffect(() => {
  setMaterialOrderInformation({
    ...materialOrderInformation,
    RMANumber: moForm.RMANumber,
  });
}, [moForm.RMANumber]);
```

### 🚨 Warning:

> ⚠️ **This is a temporary and fragile fix. It introduces reactive coupling between states, risking unintended side effects and infinite loops in future modifications.**

---

### 📌 TODO:

```ts
/**
 * TODO (WARNING ISSUE)
 * REMOVE `moForm`, use `materialOrderInformation` only.
 * This will also change the handleSave function.
 */
```

* ✅ Refactor input bindings to rely solely on `materialOrderInformation`.
* ✅ Adjust `handleMoFormChange` to be deprecated or merged into a unified change handler.
* ✅ Simplify `saveMaterialOrder()` to eliminate fallback merging logic.

---

### 🧠 Why This Matters:

Maintaining a single source of truth (`materialOrderInformation`) will:

* Prevent bugs from desynchronized state.
* Improve maintainability and developer clarity.
* Ensure consistent and reliable backend payload construction.

---

### 🇮🇩 Indonesian Translation:

## ⚠️ Laporan Masalah: Penanganan State Ganda di `service-materialApo.jsx` – *MoForm vs materialOrderInformation*

### 🗂️ File yang Terpengaruh:

`service-materialApo.jsx`

### 📌 Ringkasan:

Terdapat dua state (`moForm` dan `materialOrderInformation`) yang mengelola data yang sama, seperti `SalesOrderNumber` dan `RMANumber`. Hal ini menyebabkan potensi inkonsistensi dalam input dan logika penyimpanan.

---

### 🧾 Deskripsi:

Dua state berikut saat ini digunakan secara paralel:

```js
const [moForm, setMoForm] = useState({ SalesOrderNumber: "", RMANumber: "" });
```

```js
const [materialOrderInformation, setMaterialOrderInformation] = useState({ ..., SalesOrderNumber: "", RMANumber: "", ... });
```

Untuk mengatasi perbedaan data sementara, developer membuat `useEffect` untuk menyinkronkan kedua state tersebut. Namun, ini hanya solusi sementara dan dapat memunculkan bug tambahan di masa depan.

### 🚨 Peringatan:

> ⚠️ **Fix ini bersifat sementara dan rapuh. Sinkronisasi reaktif antar state sangat berisiko dan sulit dirawat.**

---

### 📌 TODO:

```ts
/**
 * TODO (PERINGATAN MASALAH)
 * Hapus `moForm`, gunakan hanya `materialOrderInformation`.
 * Ini juga akan mengubah fungsi handleSave.
 */
```

* ✅ Refactor seluruh binding input agar hanya menggunakan `materialOrderInformation`.
* ✅ Hapus atau gabungkan `handleMoFormChange`.
* ✅ Sederhanakan `saveMaterialOrder()` agar tidak menggunakan logika fallback dari `moForm`.

---

### 🧠 Mengapa Ini Penting:

Menggunakan satu sumber data (`materialOrderInformation`) akan:

* Menghindari bug dari state yang tidak sinkron.
* Meningkatkan keterbacaan dan kemudahan perawatan kode.
* Memastikan konsistensi payload ke backend.
