### PR TITLE
Refactor Material Order Form Handling — Remove Redundant `moForm` Sta…

### DIFF
--- a/test-vite/src/pages/services/service-case.jsx
+++ b/test-vite/src/pages/services/service-case.jsx
@@ -941,7 +941,7 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
   );
 };
 
-export const TabsServiceMO = ({ materialOrders, updatedLineItems, moForm, setMoForm, materialOrderInformation }) => {
+export const TabsServiceMO = ({ materialOrders, updatedLineItems, materialOrderInformation }) => {
   const {user} = useAuth();
   const navigate = useNavigate();
   const currentRole = (getUserFromToken()?.role || '').toLowerCase();
@@ -990,8 +990,8 @@ export const TabsServiceMO = ({ materialOrders, updatedLineItems, moForm, setMoF
       const hasShippingUpdate = updatedLineItems && Object.values(updatedLineItems).some(
         (v) => String(v).toLowerCase() === 'shipped' || String(v).toLowerCase() === 'ordered'
       );
-      const soNumber = (moForm?.SalesOrderNumber ?? materialOrderInformation?.SalesOrderNumber ?? materialOrders?.SalesOrderNumber ?? '').toString().trim();
-      const rmaNumber = (moForm?.RMANumber ?? materialOrderInformation?.RMANumber ?? materialOrders?.RMANumber ?? '').toString().trim();
+      const soNumber = (materialOrderInformation?.SalesOrderNumber ?? materialOrders?.SalesOrderNumber ?? '').toString().trim();
+      const rmaNumber = (materialOrderInformation?.RMANumber ?? materialOrders?.RMANumber ?? '').toString().trim();
       // return console.log(soNumber, moForm, materialOrderInformation);
       if (hasShippingUpdate && (!soNumber || !rmaNumber)) {
         Swal.close();

--- a/test-vite/src/pages/services/service-materialApo.jsx
+++ b/test-vite/src/pages/services/service-materialApo.jsx
@@ -56,7 +56,7 @@ export const ServiceMaterialApo = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const { moid } = useParams();
-  const {updateDraft } = useDraft(); 
+  const {updateDraft } = useDraft(); // Access updateDraft from the DraftContext
   const [materialOrders, setMaterialOrders] = useState([]);
   const [materialLineOrders, setMaterialLineOrders] = useState([]);
   const [MaterialOrder, setMaterialOrder] = useState([]);
@@ -164,6 +164,9 @@ export const ServiceMaterialApo = () => {
     })
   };
 
+
+
+  // Fetch Material Order
   const fetchMaterialOrder = async () => {
     try {
       const res = await ApiCustomer.get(`/api/material-order/${moid}`);
@@ -171,6 +174,7 @@ export const ServiceMaterialApo = () => {
 
       setMaterialOrders(data);
     
+      // Save the material order information to the state
       setMaterialOrderInformation({
         MOID: data.MOID || "",
         orderNumber: data.MOID || "",
@@ -248,6 +252,7 @@ export const ServiceMaterialApo = () => {
       },
     });
 
+    // Run both fetch functions in parallel
     Promise.all([fetchMaterialOrder(), fetchMaterialLineOrdersInMODetail()])
       .then(() => {
         Swal.close();
@@ -577,6 +582,7 @@ export const ServiceMaterialApo = () => {
               </Card>
             </div>
             
+            {/* Booking */}
             <Card className="flex-col mt-5">
               <span className="ml-5 text-xl font-bold">Booking</span>
               <CardContent className="grid">
@@ -606,6 +612,8 @@ export const ServiceMaterialApo = () => {
               </CardContent>
             </Card>
 
+            
+            {/* Material Order Line Items */}
             <Card className="flex-col mt-7">
               <span className="ml-5 text-xl font-bold">
                 Material Order Line Items

--- a/test-vite/src/pages/services/service-materialApo.jsx
+++ b/test-vite/src/pages/services/service-materialApo.jsx
@@ -43,6 +43,7 @@ import { Accordion, AccordionContent } from "@/components/ui/accordion";
 import { AccordionItem, AccordionTrigger } from "@radix-ui/react-accordion";
 import CaseField from "@/components/CaseField";
 import { useAuth } from "@/context/auth-context";
+import { toast } from "sonner";
 
 export const RMA_STATUS_OPTIONS = [
   { value: "InOutCE", label: "In/Out CE" },
@@ -59,15 +60,17 @@ export const ServiceMaterialApo = () => {
   const [materialOrders, setMaterialOrders] = useState([]);
   const [materialLineOrders, setMaterialLineOrders] = useState([]);
   const [MaterialOrder, setMaterialOrder] = useState([]);
+
+  const [rmaWarning, setRmaWarning] = useState("");
   /**
    * TODO (WARNING ISSUES) 
    * REMOVE MO FORM, USE STATE DEFINED ONE. 
    * this will also change the handle Save Function.
    */
-  const [moForm, setMoForm] = useState({
-    SalesOrderNumber: "",
-    RMANumber: "",
-  })
+  // const [moForm, setMoForm] = useState({
+  //   SalesOrderNumber: "",
+  //   RMANumber: "",
+  // })
   const [materialOrderInformation, setMaterialOrderInformation] = useState({
     MOID: "",
     orderNumber: "",
@@ -136,10 +139,10 @@ export const ServiceMaterialApo = () => {
     },
   };
 
-  const handleMoFormChange = (field) => (e) => {
-    const value = e.target.value;
-    setMoForm((prev) => ({ ...prev, [field]: value }));
-  };
+  // const handleMoFormChange = (field) => (e) => {
+  //   const value = e.target.value;
+  //   setMoForm((prev) => ({ ...prev, [field]: value }));
+  // };
 
   const handleMaterialOrderChange = (field) => (valueOrEvent) => {
     const value =
@@ -147,10 +150,34 @@ export const ServiceMaterialApo = () => {
         ? valueOrEvent.target.value
         : valueOrEvent;
 
-    setMaterialOrderInformation((prev) => ({
-      ...prev,
-      [field]: value,
-    }));
+    setMaterialOrderInformation((prev) => {
+      const updated = { ...prev, [field]: value};
+
+      if(field === "SalesOrderNumber"){
+        if(prev.RMANumber && prev.RMANumber.length > 0){
+          if(prev.RMANumber.startsWith(value)){
+            setRmaWarning("");
+          } else{
+            setRmaWarning("⚠️ RMA Number tidak sesuai dengan Sales Order Number");
+          }
+        } else{
+          setRmaWarning("");
+        }
+      }
+
+      if(field === "RMANumber"){
+        if(value && prev.SalesOrderNumber){
+          if(value.startsWith(prev.SalesOrderNumber)){
+            setRmaWarning("");
+          }else{
+            setRmaWarning("⚠️ RMA Number tidak sesuai dengan Sales Order Number")
+          }
+        }else{
+          setRmaWarning("");
+        }
+      }
+      return updated;
+    })
   };
 
 
@@ -197,14 +224,15 @@ export const ServiceMaterialApo = () => {
         eotOrderNumber: data.EOTOrderNumber || "",
         AWB_InCode: data.AWB_InCode || "",
         AWB_OutCode: data.AWB_OutCode || "",
-        RMAStatus: data.RMAStatus || null
+        RMAStatus: data.RMAStatus || null,
+        RMANumber: data.RMANumber || "",
       });
 
-      setMoForm((prev) => ({
-      ...prev,
-      SalesOrderNumber: data.SalesOrderNumber || "",
-      RMANumber: data.RMANumber || ""
-    }));
+    //   setMoForm((prev) => ({
+    //   ...prev,
+    //   SalesOrderNumber: data.SalesOrderNumber || "",
+    //   RMANumber: data.RMANumber || ""
+    // }));
 
       console.log("Fetched Material Order:", data);
 
@@ -288,28 +316,28 @@ export const ServiceMaterialApo = () => {
   //   canEditapo = materialOrders?.workorder?.caseinformation?.Owner === user?.id && allowedRoles.includes(user?.role); ;
   // }
 
-  useEffect(() => {
-    // setMoForm({
-    //   ...moForm,
-    //   RMANumber: moForm.SalesOrderNumber
-    // })
-    console.log("TEST MO FORM : ", moForm.SalesOrderNumber, materialOrderInformation.SalesOrderNumber)
-    setMaterialOrderInformation(prev => ({
-      ...prev,
-      SalesOrderNumber: moForm.SalesOrderNumber,
-      // RMANumber: moForm.SalesOrderNumber
-    }))
-  },[moForm.SalesOrderNumber])
+  // useEffect(() => {
+  //   // setMoForm({
+  //   //   ...moForm,
+  //   //   RMANumber: moForm.SalesOrderNumber
+  //   // })
+  //   console.log("TEST MO FORM : ", moForm.SalesOrderNumber, materialOrderInformation.SalesOrderNumber)
+  //   setMaterialOrderInformation(prev => ({
+  //     ...prev,
+  //     SalesOrderNumber: moForm.SalesOrderNumber,
+  //     // RMANumber: moForm.SalesOrderNumber
+  //   }))
+  // },[moForm.SalesOrderNumber])
 
-  /**
-   * TODO : REMOVE THIS LATER IF THE MOFORM IS REMOVED
-   */
-  useEffect(() =>{
-    setMaterialOrderInformation(prev => ({
-      ...prev,
-      RMANumber: moForm.RMANumber
-    }))
-  },[moForm.RMANumber])
+  // /**
+  //  * TODO : REMOVE THIS LATER IF THE MOFORM IS REMOVED
+  //  */
+  // useEffect(() =>{
+  //   setMaterialOrderInformation(prev => ({
+  //     ...prev,
+  //     RMANumber: moForm.RMANumber
+  //   }))
+  // },[moForm.RMANumber])
   
   return (
     <div>
@@ -322,8 +350,8 @@ export const ServiceMaterialApo = () => {
       <TabsServiceMO 
         materialOrders={materialOrders} 
         updatedLineItems={updatedLineItems}
-        moForm={moForm}
-        setMoForm={setMoForm}
+        // moForm={moForm}
+        // setMoForm={setMoForm}
         materialOrderInformation={materialOrderInformation}
       />
       <Card className="mt-2 rounded-none">
@@ -434,12 +462,16 @@ export const ServiceMaterialApo = () => {
                     <Input
                       variant={"invisible"}
                       type="text"
-                      value={moForm?.SalesOrderNumber || ""}
+                      value={materialOrderInformation?.SalesOrderNumber || ""}
                       placeholder="---"
-                      onChange={(e) => {
-                        const val = e.target.value
-                        handleMoFormChange("SalesOrderNumber")(e)
-                        handleMoFormChange("RMANumber")(e)
+                      onChange={handleMaterialOrderChange("SalesOrderNumber")}
+                      onBlur={() =>{
+                        if (!materialOrderInformation?.RMANumber) {
+                          setMaterialOrderInformation(prev => ({
+                            ...prev,
+                            RMANumber: prev.SalesOrderNumber
+                          }))
+                        }
                       }}
                     />
                   </CaseField>
@@ -455,9 +487,14 @@ export const ServiceMaterialApo = () => {
 
                   <CaseField label="RMA Number" star={canEditapo} lock={!canEditapo}>
                     <Input variant="invisible" placeholder="---" 
-                    value={moForm?.RMANumber || ""}
-                    onChange={handleMoFormChange("RMANumber")}
+                    value={materialOrderInformation?.RMANumber || ""}
+                    onChange={handleMaterialOrderChange("RMANumber")}
                     />
+                    {rmaWarning && (
+                      <span style={{ color: "orange", fontSize: "0.8rem", marginTop: 2 }}>
+                        {rmaWarning}
+                      </span>
+                    )}
                   </CaseField>  
 
                   <CaseField

--- a/test-vite/src/pages/services/service-materialApo.jsx
+++ b/test-vite/src/pages/services/service-materialApo.jsx
@@ -56,21 +56,12 @@ export const ServiceMaterialApo = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const { moid } = useParams();
-  const {updateDraft } = useDraft(); // Access updateDraft from the DraftContext
+  const {updateDraft } = useDraft(); 
   const [materialOrders, setMaterialOrders] = useState([]);
   const [materialLineOrders, setMaterialLineOrders] = useState([]);
   const [MaterialOrder, setMaterialOrder] = useState([]);
 
   const [rmaWarning, setRmaWarning] = useState("");
-  /**
-   * TODO (WARNING ISSUES) 
-   * REMOVE MO FORM, USE STATE DEFINED ONE. 
-   * this will also change the handle Save Function.
-   */
-  // const [moForm, setMoForm] = useState({
-  //   SalesOrderNumber: "",
-  //   RMANumber: "",
-  // })
   const [materialOrderInformation, setMaterialOrderInformation] = useState({
     MOID: "",
     orderNumber: "",
@@ -101,8 +92,6 @@ export const ServiceMaterialApo = () => {
     RMAStatus: null,
     RMANumber: "",
   });
-  // const [collectionRequestedDate, setCollectionRequestedDate] = useState(null);
-  // const [readyForClosureDate, setReadyForClosureDate] = useState(null);
   const [error, setError] = useState(null);
 
   const [updatedLineItems, setUpdatedLineItems] = useState({}); 
@@ -130,19 +119,14 @@ export const ServiceMaterialApo = () => {
 
   const DateHelper = {
     fromDB(dateStr) {
-      // DB → UI
+      
       return formatDateForInput(dateStr);
     },
     toDB(dateStr) {
-      // UI → DB
+      
       return dateStr ? new Date(dateStr).toISOString() : null;
     },
   };
-
-  // const handleMoFormChange = (field) => (e) => {
-  //   const value = e.target.value;
-  //   setMoForm((prev) => ({ ...prev, [field]: value }));
-  // };
 
   const handleMaterialOrderChange = (field) => (valueOrEvent) => {
     const value =
@@ -180,9 +164,6 @@ export const ServiceMaterialApo = () => {
     })
   };
 
-
-
-  // Fetch Material Order
   const fetchMaterialOrder = async () => {
     try {
       const res = await ApiCustomer.get(`/api/material-order/${moid}`);
@@ -190,7 +171,6 @@ export const ServiceMaterialApo = () => {
 
       setMaterialOrders(data);
     
-      // Save the material order information to the state
       setMaterialOrderInformation({
         MOID: data.MOID || "",
         orderNumber: data.MOID || "",
@@ -228,16 +208,9 @@ export const ServiceMaterialApo = () => {
         RMANumber: data.RMANumber || "",
       });
 
-    //   setMoForm((prev) => ({
-    //   ...prev,
-    //   SalesOrderNumber: data.SalesOrderNumber || "",
-    //   RMANumber: data.RMANumber || ""
-    // }));
-
       console.log("Fetched Material Order:", data);
 
-      // Update the draft with the fetched material order details
-      updateDraft("moid", data.MOID); // Save the entire material order to the draft
+      updateDraft("moid", data.MOID);
     } catch (err) {
       console.error("Failed to fetch material orders:", err);
       setError("Failed to fetch material order data");
@@ -252,7 +225,6 @@ export const ServiceMaterialApo = () => {
     { value: "notes_attaechment", label: "Notes & Attachment", hidden: true },
   ];
 
-  // Fetch Material Line Orders
   const fetchMaterialLineOrdersInMODetail = async () => {
     try {
       const res = await ApiCustomer.get(
@@ -276,7 +248,6 @@ export const ServiceMaterialApo = () => {
       },
     });
 
-    // Run both fetch functions in parallel
     Promise.all([fetchMaterialOrder(), fetchMaterialLineOrdersInMODetail()])
       .then(() => {
         Swal.close();
@@ -286,7 +257,6 @@ export const ServiceMaterialApo = () => {
       });
   }, [moid]);
 
-  // If error state is set, display error message to user
   if (error) {
     return (
       <div className="error-message">
@@ -310,34 +280,6 @@ export const ServiceMaterialApo = () => {
   }
 
   console.log("tw", materialOrders?.workorder?.caseinformation?.Owner)
-  // if (user?.role === "admin") {
-  //   canEditapo = true;
-  // } else if (materialOrders?.workorder?.caseinformation?.Owner) {
-  //   canEditapo = materialOrders?.workorder?.caseinformation?.Owner === user?.id && allowedRoles.includes(user?.role); ;
-  // }
-
-  // useEffect(() => {
-  //   // setMoForm({
-  //   //   ...moForm,
-  //   //   RMANumber: moForm.SalesOrderNumber
-  //   // })
-  //   console.log("TEST MO FORM : ", moForm.SalesOrderNumber, materialOrderInformation.SalesOrderNumber)
-  //   setMaterialOrderInformation(prev => ({
-  //     ...prev,
-  //     SalesOrderNumber: moForm.SalesOrderNumber,
-  //     // RMANumber: moForm.SalesOrderNumber
-  //   }))
-  // },[moForm.SalesOrderNumber])
-
-  // /**
-  //  * TODO : REMOVE THIS LATER IF THE MOFORM IS REMOVED
-  //  */
-  // useEffect(() =>{
-  //   setMaterialOrderInformation(prev => ({
-  //     ...prev,
-  //     RMANumber: moForm.RMANumber
-  //   }))
-  // },[moForm.RMANumber])
   
   return (
     <div>
@@ -510,7 +452,6 @@ export const ServiceMaterialApo = () => {
                     />
                   </CaseField>
                   
-                  {/* todo for slamet : ETA DATE di MO yang ngisi APO */}
                   <CaseField
                     label={"ETA Delivery Required Date (Customer Time)"}
                     lock={!canEditapo}
@@ -522,7 +463,6 @@ export const ServiceMaterialApo = () => {
                     />
                   </CaseField>
 
-                  {/* PART IN CE */}
                   <CaseField label={"Part IN CE Collection Requested Date"} icon lock={!canEditapo}>
                     <DatePicker
                       value={materialOrderInformation?.collectionRequestedDate ? new Date(materialOrderInformation?.collectionRequestedDate) : null}
@@ -530,7 +470,6 @@ export const ServiceMaterialApo = () => {
                     />
                   </CaseField>
 
-                  {/* Part OUT CE */}
                   <CaseField label={"Part OUT CE Ready For Closure Date"} icon lock={!canEditapo}>
                     <DatePicker
                       value={materialOrderInformation?.readyForClosureDate ? new Date(materialOrderInformation?.readyForClosureDate) : null}
@@ -538,14 +477,12 @@ export const ServiceMaterialApo = () => {
                     />
                   </CaseField>
 
-                  {/* AWB IN CODE */}
                   <CaseField label={"AWB In Code"} icon lock={!canEditapo}>
                     <Input variant="invisible" placeholder="---"               
                       value={materialOrderInformation?.AWB_InCode || null}
                       onChange={handleMaterialOrderChange("AWB_InCode")}
                     />
                   </CaseField>
-                  {/* AWB OUT CODE */}
                   <CaseField label={"AWB Out Code"} icon lock={!canEditapo}>
                     <Input variant="invisible" placeholder="---" 
                       value={materialOrderInformation?.AWB_OutCode || null}
@@ -640,7 +577,6 @@ export const ServiceMaterialApo = () => {
               </Card>
             </div>
             
-            {/* Booking */}
             <Card className="flex-col mt-5">
               <span className="ml-5 text-xl font-bold">Booking</span>
               <CardContent className="grid">
@@ -670,8 +606,6 @@ export const ServiceMaterialApo = () => {
               </CardContent>
             </Card>
 
-            
-            {/* Material Order Line Items */}
             <Card className="flex-col mt-7">
               <span className="ml-5 text-xl font-bold">
                 Material Order Line Items
@@ -719,12 +653,11 @@ export const ServiceMaterialApo = () => {
                               <SelectItem value="Ordered">Ordered</SelectItem>
                               <SelectItem value="Shipped">Shipped</SelectItem>
                               <SelectItem value="BackOrdered">BackOrdered</SelectItem>
-                              {/* <SelectItem value="Closed">Closed</SelectItem>
-                              <SelectItem value="Cancelled">Cancelled</SelectItem> */}
+                              <SelectItem value="Closed">Closed</SelectItem>
+                              <SelectItem value="Cancelled">Cancelled</SelectItem>
                             </SelectContent>
                           </Select>
                         </TableCell>
-                        {/* <TableCell>{lineitem.Status}</TableCell> */}
                         <TableCell>{lineitem.ATPStatus}</TableCell>
                         <TableCell>{lineitem.PartNumber}</TableCell>
                         <TableCell>{lineitem.Description}</TableCell>

--- a/test-vite/src/pages/services/service-mo_detailApo.jsx
+++ b/test-vite/src/pages/services/service-mo_detailApo.jsx
@@ -78,17 +78,15 @@ function formatDateForInput(dateString) {
 
 const DateHelper = {
   fromDB(dateStr) {
-    // DB → UI
     return formatDateForInput(dateStr);
   },
   toDB(dateStr) {
-    // UI → DB
     return dateStr ? new Date(dateStr).toISOString() : null;
   },
 };
 
 export const ServiceMoDetailApo = () => {
-  const { updateDraft } = useDraft(); // Access updateDraft from the DraftContext
+  const { updateDraft } = useDraft(); 
   const {user} = useAuth();
   const { lineItemID } = useParams();
 
@@ -140,7 +138,6 @@ export const ServiceMoDetailApo = () => {
 
   const fetchMoLineItems = async () => {
     try {
-      // Tampilkan loading SweetAlert
       Swal.fire({
         title: "Loading...",
         text: "Please wait a moment",
@@ -158,8 +155,6 @@ export const ServiceMoDetailApo = () => {
       const data = res.data.data;
 
       setMoLineItems(data);
-
-      // Isi state MODetailInput berdasarkan data yang diambil
       setMODetailInput({
         MOID: data.MOID,
         moOrderName: data ? `${data.MOID} - ${data.LineNumber}` : null,
@@ -225,14 +220,6 @@ export const ServiceMoDetailApo = () => {
 
     fetchPartReturnStatuses();
   }, []);
-
-  // const handleChange = (e) => {
-  //   const { name, value } = e.target;
-  //   setMODetailInput((prev) => ({
-  //     ...prev,
-  //     [name]: value,
-  //   }));
-  // };
 
   const handleChange = (field) => (eOrValue) => {
     const value = eOrValue?.target ? eOrValue.target.value : eOrValue;
@@ -487,12 +474,12 @@ export const ServiceMoDetailApo = () => {
 
   const [inputValue, setInputValue] = useState("");
   const [searchResults, setSearchResults] = useState([]);
-  const [isFocused, setIsFocused] = useState(false); // Track if input is focused
+  const [isFocused, setIsFocused] = useState(false); 
 
 useEffect(() => {
   ApiCustomer.get("/api/failure/options").then((res) => {
     const defaultOptions = res.data.map((f, index) => ({
-      value: f.FailureId.toString(), // value selalu string
+      value: f.FailureId.toString(), 
       label: (
         <div className="flex flex-col">
           <span className="font-medium">
@@ -509,7 +496,7 @@ useEffect(() => {
     ApiCustomer.get(`/api/failure/${MODetailInput.failureId}`)
       .then((res) => {
         const f = res.data.data;
-        setInputValue(f.FailureId.toString()); // tetap string di state
+        setInputValue(f.FailureId.toString()); 
       })
       .catch(() => {
         
@@ -552,13 +539,12 @@ useEffect(() => {
     console.log("selected.value", selected.value);
   };
 
-  // Handle focus and blur events
   const handleFocus = () => {
     setIsFocused(true);
   };
 
   const handleBlur = () => {
-    setTimeout(() => setIsFocused(false), 150); // Delay to allow click on dropdown
+    setTimeout(() => setIsFocused(false), 150);
   };
 
   const tabs = [

--- a/test-vite/src/pages/services/service-mo_detailApo.jsx
+++ b/test-vite/src/pages/services/service-mo_detailApo.jsx
@@ -86,7 +86,7 @@ const DateHelper = {
 };
 
 export const ServiceMoDetailApo = () => {
-  const { updateDraft } = useDraft(); 
+  const { updateDraft } = useDraft(); // Access updateDraft from the DraftContext
   const {user} = useAuth();
   const { lineItemID } = useParams();
 


### PR DESCRIPTION
Refactor Material Order Form Handling — Remove Redundant `moForm` State and Sync with `materialOrderInformation`

---

### 📝 **Description**

This PR fix issue #115, which refactors the Material Order handling logic in `service-materialApo.jsx` and `service-case.jsx` to simplify state management and improve data consistency between form inputs and backend data.

---

### 🔧 **Changes Made**

* Removed redundant `moForm` state and related `setMoForm`/`handleMoFormChange` logic.
* Updated `TabsServiceMO` props to use only `materialOrderInformation` (removed `moForm`).
* Implemented unified state handler `handleMaterialOrderChange` for both **Sales Order Number** and **RMA Number**.
* Added real-time validation for RMA Number consistency with Sales Order Number.
* Added warning message when RMA Number doesn’t match Sales Order prefix.
* Improved form behavior:

  * Automatically syncs RMANumber with SalesOrderNumber when empty.
  * Prevents desynchronization between UI and API data.
* Removed obsolete `useEffect` hooks that sync `moForm` to `materialOrderInformation`.

---

### 💡 **Why This Change**

Previously, both `moForm` and `materialOrderInformation` stored overlapping data, leading to:

* Double state updates,
* Inconsistent validation behavior,
* Unnecessary side effects.

By consolidating them into a single source of truth (`materialOrderInformation`), the form becomes cleaner, easier to maintain, and less error-prone.

---

### ✅ **Tested Scenarios**

* [x] Changing **Sales Order Number** auto-fills **RMA Number** when empty
* [x] RMA Number validation shows correct warning if mismatched
* [x] TabsServiceMO no longer depends on `moForm`
* [x] Data fetched from backend correctly populates fields

---

### 🧹 **Next Steps**

* Ensure all references to `moForm` are cleaned from related components.
* Confirm `handleSave` logic works with updated state structure.