### PR TITLE
✨ Pull Request — Invoice System, Quotation Flow Upgrade, and Case/WO Enhancements

### DIFF
--- a/next-api/prisma/migrations/20251113081835_adding_invoice_table_with_wo_cancel_projection/migration.sql
+++ b/next-api/prisma/migrations/20251113081835_adding_invoice_table_with_wo_cancel_projection/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable
+ALTER TABLE `workorder` ADD COLUMN `CancelReason` TEXT NULL,
+    ADD COLUMN `IsCancel` BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE `invoicetable` (
+    `InvoiceNo` VARCHAR(8) NOT NULL,
+    `QuotationNo` VARCHAR(8) NOT NULL,
+    `AmountReceive` DECIMAL(65, 30) NOT NULL DEFAULT 0,
+    `AmountDiff` DECIMAL(65, 30) NOT NULL DEFAULT 0,
+    `AmountDiffReason` TEXT NULL,
+    `PaymentType` VARCHAR(20) NULL,
+    `AmountReceiveDate` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+    `AmountReceiveNote` TEXT NULL,
+    `SendWa` BOOLEAN NOT NULL DEFAULT false,
+    `SendEmail` BOOLEAN NOT NULL DEFAULT false,
+    `SendInvoice` BOOLEAN NOT NULL DEFAULT false,
+    `SendERF` BOOLEAN NOT NULL DEFAULT false,
+
+    PRIMARY KEY (`InvoiceNo`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `invoicetable` ADD CONSTRAINT `invoicetable_QuotationNo_fkey` FOREIGN KEY (`QuotationNo`) REFERENCES `quotationtable`(`QuotationNo`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/next-api/prisma/migrations/20251113082719_add_a_fucking_cancel_status_on_case/migration.sql
+++ b/next-api/prisma/migrations/20251113082719_add_a_fucking_cancel_status_on_case/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `caseinformation` MODIFY `CaseStatus` ENUM('New', 'Open', 'InActive', 'Close', 'Cancel', 'Active', 'Monitor', 'Pending_Customer_Action', 'Quote_Requested', 'Pending_Follow_Up', 'Pending_Order', 'Escalated', 'Quote_Approved', 'Quote_Rejected', 'Pending_Quote', 'NEW_AssignCE', 'NEW_AssignAPO', 'NEW_AssignLeader', 'NEW_AssignPS', 'NEW_POPDoc', 'NEW_Warranty', 'AssignCE', 'AssignAPO', 'AssignLeader', 'AssignPS', 'PartOrder', 'PartRequest', 'PartRequestLog', 'PartAvailable', 'RepairProgress', 'FinishRepair', 'CancelRepair') NOT NULL DEFAULT 'Open';

--- a/next-api/prisma/migrations/20251113092846_asuu_kelupaan_created_by_nya_asu/migration.sql
+++ b/next-api/prisma/migrations/20251113092846_asuu_kelupaan_created_by_nya_asu/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `CreatedBy` to the `invoicetable` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `invoicetable` ADD COLUMN `CreatedBy` INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE `invoicetable` ADD CONSTRAINT `invoicetable_CreatedBy_fkey` FOREIGN KEY (`CreatedBy`) REFERENCES `User`(`IDUser`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/next-api/prisma/migrations/20251117073009_akawokawok_lupa_nambahin_limit_decimal_di_invoice_njir/migration.sql
+++ b/next-api/prisma/migrations/20251117073009_akawokawok_lupa_nambahin_limit_decimal_di_invoice_njir/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `AmountReceive` on the `invoicetable` table. The data in that column could be lost. The data in that column will be cast from `Decimal(65,30)` to `Decimal(12,2)`.
+  - You are about to alter the column `AmountDiff` on the `invoicetable` table. The data in that column could be lost. The data in that column will be cast from `Decimal(65,30)` to `Decimal(12,2)`.
+
+*/
+-- AlterTable
+ALTER TABLE `invoicetable` MODIFY `AmountReceive` DECIMAL(12, 2) NOT NULL DEFAULT 0,
+    MODIFY `AmountDiff` DECIMAL(12, 2) NOT NULL DEFAULT 0;

--- a/next-api/prisma/schema.prisma
+++ b/next-api/prisma/schema.prisma
@@ -241,8 +241,8 @@ model invoicetable {
   InvoiceNo         String         @id @db.VarChar(8)
   QuotationNo       String         @db.VarChar(8)
   quotation         quotationtable @relation(fields: [QuotationNo], references: [QuotationNo], onDelete: Restrict)
-  AmountReceive     Decimal        @default(0)
-  AmountDiff        Decimal        @default(0)
+  AmountReceive     Decimal        @default(0) @db.Decimal(12, 2) //AWKOAKOWKAOWKOAWK LUPA NAMBAHIN LIMIT DECIMAL AJG
+  AmountDiff        Decimal        @default(0) @db.Decimal(12, 2)
   AmountDiffReason  String?        @db.Text
   PaymentType       String?        @db.VarChar(20)
   AmountReceiveDate DateTime       @default(now()) @db.DateTime(0)

--- a/next-api/prisma/schema.prisma
+++ b/next-api/prisma/schema.prisma
@@ -237,6 +237,26 @@ model global_trade_check {
   caseinformation caseinformation[]
 }
 
+model invoicetable {
+  InvoiceNo         String         @id @db.VarChar(8)
+  QuotationNo       String         @db.VarChar(8)
+  quotation         quotationtable @relation(fields: [QuotationNo], references: [QuotationNo], onDelete: Restrict)
+  AmountReceive     Decimal        @default(0)
+  AmountDiff        Decimal        @default(0)
+  AmountDiffReason  String?        @db.Text
+  PaymentType       String?        @db.VarChar(20)
+  AmountReceiveDate DateTime       @default(now()) @db.DateTime(0)
+  AmountReceiveNote String?        @db.Text
+
+  SendWa      Boolean @default(false)
+  SendEmail   Boolean @default(false)
+  SendInvoice Boolean @default(false)
+  SendERF     Boolean @default(false)
+
+  CreatedBy     Int
+  CreatedByUser User @relation("UserInvoiceAdmin", fields: [CreatedBy], references: [IDUser], onDelete: Restrict)
+}
+
 model quotationtable {
   QuotationNo           String             @id @db.VarChar(8)
   QuotationType         QuotationType      @default(Simple)
@@ -256,6 +276,7 @@ model quotationtable {
 
   GrandTotal         Decimal?             @db.Decimal(10, 2) // Total akhir
   quotation_lineitem quotation_lineitem[]
+  invoicetable       invoicetable[]
 }
 
 model quotation_lineitem {
@@ -554,6 +575,7 @@ model User {
   caseNotes_created casenotes[] @relation("UserCreatedCaseNotes")
 
   quotationtable quotationtable[] @relation("UserQuotationAdmin")
+  invoicetable   invoicetable[]   @relation("UserInvoiceAdmin")
 }
 
 model warranty_services {
@@ -712,6 +734,9 @@ model workorder {
   CEAnalysis    String?      @db.Text
   DefectDesc    String?      @db.Text
   RepairAction  String?      @db.Text
+
+  IsCancel     Boolean @default(false)
+  CancelReason String? @db.Text
 
   @@unique([ServiceCatalogID])
   @@index([CaseID], map: "CaseID")
@@ -897,6 +922,7 @@ enum CaseStatus {
   Open
   InActive
   Close
+  Cancel //KELUPAAN KONTOL
   Active
   Monitor
   Pending_Customer_Action

--- a/next-api/src/app/api/case-information/route.js
+++ b/next-api/src/app/api/case-information/route.js
@@ -103,7 +103,15 @@ export async function GET(request) {
         include: {
           materialorder: {
             include: {
-              materialorderlineitems: true,
+              materialorderlineitems: {
+                include :{
+                  quotation_lineitem :{
+                    include: {
+                      quotation: true
+                    }
+                  }
+                }
+              },
               owner: true
             }
           },

--- a/next-api/src/app/api/invoice-information/[InvoiceNo]/route.js
+++ b/next-api/src/app/api/invoice-information/[InvoiceNo]/route.js
@@ -9,6 +9,11 @@ import {
 } from "../helpers";
 
 export async function PATCH(request, { params }) {
+  return NextResponse.json(
+    { success: false, message: "Belum ada patch. heheh" },
+    { status: 402 }
+  );
+  // return console.log("PATCH",request)
   try {
     const invoiceNo = params?.InvoiceNo;
     if (!invoiceNo) {

--- a/next-api/src/app/api/invoice-information/[InvoiceNo]/route.js
+++ b/next-api/src/app/api/invoice-information/[InvoiceNo]/route.js
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server";
+import prisma from "../../../../../prisma/client";
+import { parseDate, toBooleanFlag } from "../../quotation-information/helpers";
+import {
+  decimalToNumber,
+  mapInvoicePayload,
+  normaliseDecimalInput,
+  normaliseReason,
+} from "../helpers";
+
+export async function PATCH(request, { params }) {
+  try {
+    const invoiceNo = params?.InvoiceNo;
+    if (!invoiceNo) {
+      return NextResponse.json(
+        { success: false, message: "InvoiceNo tidak valid." },
+        { status: 400 }
+      );
+    }
+
+    const existing = await prisma.invoicetable.findUnique({
+      where: { InvoiceNo: invoiceNo },
+      include: { quotation: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json(
+        { success: false, message: "Invoice tidak ditemukan." },
+        { status: 404 }
+      );
+    }
+
+    const body = await request.json();
+    const data = {};
+
+    if (body.amountReceive !== undefined) {
+      const receiveAmount = normaliseDecimalInput(body.amountReceive, {
+        fieldName: "Amount receive",
+      });
+      data.AmountReceive = receiveAmount.decimal;
+
+      if (body.amountDiff === undefined) {
+        const grandTotalNumber =
+          decimalToNumber(existing.quotation?.GrandTotal) ?? 0;
+        const autoDiff = normaliseDecimalInput(
+          grandTotalNumber - receiveAmount.number,
+          {
+            fieldName: "Amount difference",
+            allowNegative: true,
+          }
+        );
+        data.AmountDiff = autoDiff.decimal;
+      }
+    }
+
+    if (body.amountDiff !== undefined) {
+      const diffAmount = normaliseDecimalInput(body.amountDiff, {
+        fieldName: "Amount difference",
+        allowNegative: true,
+      });
+      data.AmountDiff = diffAmount.decimal;
+    }
+
+    if (body.amountReceiveDate !== undefined) {
+      data.AmountReceiveDate = parseDate(body.amountReceiveDate) ?? new Date();
+    }
+
+    if (body.paymentType !== undefined) {
+      data.PaymentType = body.paymentType?.trim() || null;
+    }
+
+    if (body.amountReceiveNote !== undefined) {
+      data.AmountReceiveNote = body.amountReceiveNote?.trim() || null;
+    }
+
+    const booleanFields = [
+      ["SendWa", "sendWa"],
+      ["SendEmail", "sendEmail"],
+      ["SendInvoice", "sendInvoice"],
+      ["SendERF", "sendErf"],
+    ];
+
+    booleanFields.forEach(([field, key]) => {
+      if (key in body) {
+        data[field] = Boolean(toBooleanFlag(body[key]));
+      }
+    });
+
+    let reasonCandidate =
+      body.amountDiffReason !== undefined
+        ? normaliseReason(body.amountDiffReason)
+        : existing.AmountDiffReason;
+
+    const nextDiffDecimal =
+      data.AmountDiff !== undefined ? data.AmountDiff : existing.AmountDiff;
+    const nextDiffNumber = decimalToNumber(nextDiffDecimal) ?? 0;
+
+    if (nextDiffNumber !== 0 && !reasonCandidate) {
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            "Amount difference reason wajib diisi ketika terdapat selisih.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (nextDiffNumber === 0) {
+      data.AmountDiffReason = null;
+    } else if (body.amountDiffReason !== undefined) {
+      data.AmountDiffReason = reasonCandidate;
+    }
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Tidak ada perubahan yang dikirim.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const updated = await prisma.invoicetable.update({
+      where: { InvoiceNo: invoiceNo },
+      data,
+      include: { quotation: true },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "Invoice berhasil diperbarui.",
+      data: mapInvoicePayload(updated, updated.quotation),
+    });
+  } catch (error) {
+    console.error("Error updating invoice:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: "Gagal memperbarui invoice.",
+        error: error.message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/next-api/src/app/api/invoice-information/helpers.js
+++ b/next-api/src/app/api/invoice-information/helpers.js
@@ -1,0 +1,107 @@
+import { Prisma } from "@prisma/client";
+import { decimalToString } from "../quotation-information/helpers";
+
+export const AMOUNT_DIFF_REASONS = [
+  "Cancellation Fee (part mahal)",
+  "Discount",
+  "Free absorb by HP",
+  "Free cancel (Onsite)",
+  "Free EOS/Not support ID",
+  "Free harga tidak ekonomis",
+  "Free rerepair",
+  "Free unit Nexgen",
+  "Free void warranty",
+  "Partial part",
+  "PPh23 / VAT",
+  "Service Fee / Labor only",
+  "Warranty approved",
+];
+
+export const decimalToNumber = (value) => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return Number.isNaN(value) ? null : value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (typeof value.toString === "function") {
+    const parsed = Number(value.toString());
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const normaliseDecimalInput = (
+  rawValue,
+  { fieldName = "Nilai", allowNegative = false, defaultValue } = {}
+) => {
+  let value = rawValue;
+  const hasValue =
+    value !== undefined && value !== null && value !== "" && value !== false;
+
+  if (!hasValue) {
+    if (defaultValue === undefined) {
+      throw new Error(`${fieldName} wajib diisi.`);
+    }
+    value = defaultValue;
+  }
+
+  const parsed =
+    typeof value === "number" ? value : Number(String(value).replace(/,/g, ""));
+
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${fieldName} harus berupa angka yang valid.`);
+  }
+
+  if (!allowNegative && parsed < 0) {
+    throw new Error(`${fieldName} tidak boleh bernilai negatif.`);
+  }
+
+  return {
+    number: parsed,
+    decimal: new Prisma.Decimal(parsed),
+  };
+};
+
+export const normaliseReason = (value) => {
+  if (value === undefined || value === null) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  return trimmed;
+};
+
+export const mapInvoicePayload = (invoiceRecord, quotationRecord) => {
+  const invoice = invoiceRecord
+    ? {
+        invoiceNo: invoiceRecord.InvoiceNo,
+        quotationNo: invoiceRecord.QuotationNo,
+        amountReceive: decimalToString(invoiceRecord.AmountReceive),
+        amountDiff: decimalToString(invoiceRecord.AmountDiff),
+        amountDiffReason: invoiceRecord.AmountDiffReason,
+        paymentType: invoiceRecord.PaymentType,
+        amountReceiveDate:
+          invoiceRecord.AmountReceiveDate?.toISOString() ?? null,
+        amountReceiveNote: invoiceRecord.AmountReceiveNote,
+        sendWa: invoiceRecord.SendWa,
+        sendEmail: invoiceRecord.SendEmail,
+        sendInvoice: invoiceRecord.SendInvoice,
+        sendErf: invoiceRecord.SendERF,
+        createdBy: invoiceRecord.CreatedBy,
+      }
+    : null;
+
+  const quotation = quotationRecord
+    ? {
+        quotationNo: quotationRecord.QuotationNo,
+        subtotal: decimalToString(quotationRecord.Subtotal),
+        vatAmount: decimalToString(quotationRecord.VATAmount),
+        grandTotal: decimalToString(quotationRecord.GrandTotal),
+        vatValue: quotationRecord.VatValue ?? null,
+        laborFee: quotationRecord.LaborFee ?? null,
+        currency: quotationRecord.Currency ?? "IDR",
+      }
+    : null;
+
+  return { invoice, quotation };
+};

--- a/next-api/src/app/api/invoice-information/route.js
+++ b/next-api/src/app/api/invoice-information/route.js
@@ -27,6 +27,7 @@ const collectLineItemIds = (caseRecord) => {
 };
 
 export async function GET(request) {
+  
   try {
     const { searchParams } = new URL(request.url);
     const invoiceNo = searchParams.get("invoiceNo");
@@ -159,6 +160,7 @@ export async function GET(request) {
 }
 
 export async function POST(request) {
+  const prismaTx = prisma.$transaction; 
   try {
     const body = await request.json();
     const {
@@ -174,7 +176,9 @@ export async function POST(request) {
       sendInvoice,
       sendErf,
       createdBy,
+      caseId
     } = body;
+    // return console.log("POST",body)
 
     if (!quotationNo) {
       return NextResponse.json(
@@ -205,81 +209,167 @@ export async function POST(request) {
       );
     }
 
-    const existingInvoice = await prisma.invoicetable.findFirst({
-      where: { QuotationNo: quotationNo },
-    });
-
-    if (existingInvoice) {
-      return NextResponse.json(
-        {
-          success: false,
-          message: "Quotation ini sudah memiliki invoice.",
-        },
-        { status: 409 }
-      );
-    }
-
-    const receiveAmount = normaliseDecimalInput(amountReceive, {
-      fieldName: "Amount receive",
-    });
-
-    let diffAmount;
-    if (amountDiff !== undefined && amountDiff !== null && amountDiff !== "") {
-      diffAmount = normaliseDecimalInput(amountDiff, {
-        fieldName: "Amount difference",
-        allowNegative: true,
+    const result = await prisma.$transaction(async (tx) =>{
+      const quotation = await tx.quotationtable.findUnique({
+        where: {QuotationNo: quotationNo}
+      })
+      if(!quotation) throw new Error("Quotation tidak ditemukan");
+      
+      const existingInvoice = await tx.invoicetable.findFirst({
+        where: { QuotationNo: quotationNo },
       });
-    } else {
-      const grandTotalNumber = decimalToNumber(quotation.GrandTotal) ?? 0;
-      diffAmount = normaliseDecimalInput(grandTotalNumber - receiveAmount.number, {
-        fieldName: "Amount difference",
-        allowNegative: true,
-        defaultValue: 0,
+  
+      if (existingInvoice) {
+        return NextResponse.json(
+          {
+            success: false,
+            message: "Quotation ini sudah memiliki invoice.",
+          },
+          { status: 409 }
+        );
+      }
+
+      const receiveAmount = normaliseDecimalInput(amountReceive, {
+        fieldName: "Amount receive",
       });
-    }
+  
+      let diffAmount;
+      if (amountDiff !== undefined && amountDiff !== null && amountDiff !== "") {
+        diffAmount = normaliseDecimalInput(amountDiff, {
+          fieldName: "Amount difference",
+          allowNegative: true,
+        });
+      } else {
+        const grandTotalNumber = decimalToNumber(quotation.GrandTotal) ?? 0;
+        diffAmount = normaliseDecimalInput(grandTotalNumber - receiveAmount.number, {
+          fieldName: "Amount difference",
+          allowNegative: true,
+          defaultValue: 0,
+        });
+      }
 
-    const reason = normaliseReason(amountDiffReason);
-    if (diffAmount.number !== 0 && !reason) {
-      return NextResponse.json(
-        {
-          success: false,
-          message:
-            "Amount difference reason wajib diisi ketika terdapat selisih.",
-        },
-        { status: 400 }
+      const reason = normaliseReason(amountDiffReason);
+      if (diffAmount.number !== 0 && !reason) {
+        return NextResponse.json(
+          {
+            success: false,
+            message:
+              "Amount difference reason wajib diisi ketika terdapat selisih.",
+          },
+          { status: 400 }
+        );
+      }
+      
+      const invoiceNo = await generateID(
+        INVOICE_PREFIX,
+        "invoicetable",
+        "InvoiceNo"
       );
-    }
+  
+      const includeChangedBy = {
+        changedByUser: {
+            select: {
+                IDUser: true,
+                Name: true,
+                Email: true,
+            },
+        },
+      };
 
-    const invoiceNo = await generateID(
-      INVOICE_PREFIX,
-      "invoicetable",
-      "InvoiceNo"
-    );
+      const invoice = await tx.invoicetable.create({
+        data: {
+          InvoiceNo: invoiceNo,
+          QuotationNo: quotationNo,
+          AmountReceive: receiveAmount.decimal,
+          AmountDiff: diffAmount.decimal,
+          AmountDiffReason: reason,
+          PaymentType: paymentType?.trim() || null,
+          AmountReceiveDate: parseDate(amountReceiveDate) ?? new Date(),
+          AmountReceiveNote: amountReceiveNote?.trim() || null,
+          SendWa: Boolean(toBooleanFlag(sendWa)),
+          SendEmail: Boolean(toBooleanFlag(sendEmail)),
+          SendInvoice: Boolean(toBooleanFlag(sendInvoice)),
+          SendERF: Boolean(toBooleanFlag(sendErf)),
+          CreatedBy: createdById,
+        },
+        include: { quotation: true },
+      });
+      
+      const user = await tx.user.findUnique({
+        where:{
+          IDUser: createdById
+        }
+      })
 
-    const invoice = await prisma.invoicetable.create({
-      data: {
-        InvoiceNo: invoiceNo,
-        QuotationNo: quotationNo,
-        AmountReceive: receiveAmount.decimal,
-        AmountDiff: diffAmount.decimal,
-        AmountDiffReason: reason,
-        PaymentType: paymentType?.trim() || null,
-        AmountReceiveDate: parseDate(amountReceiveDate) ?? new Date(),
-        AmountReceiveNote: amountReceiveNote?.trim() || null,
-        SendWa: Boolean(toBooleanFlag(sendWa)),
-        SendEmail: Boolean(toBooleanFlag(sendEmail)),
-        SendInvoice: Boolean(toBooleanFlag(sendInvoice)),
-        SendERF: Boolean(toBooleanFlag(sendErf)),
-        CreatedBy: createdById,
-      },
-      include: { quotation: true },
-    });
+      const formatRupiah = (value) => {
+        const number = typeof value === "number" ? value : Number(value);
+        return Number.toLocaleString("id-ID", {
+          style: "currency",
+          currency: "IDR",
+          minimumFractionDigits: 0,
+        })
+      }
+
+      await tx.casenotes.create({
+          data: {
+            CaseID: caseId,
+            LogType: "System Invoice",
+            ActionType: "Action Plan",
+            Template: "",
+            VisibleExternally: true,
+            MinutesSpent: 0,
+            Note: `[INVOICE] Invoice : \nINVOICE NO : ${invoiceNo}\nAmount Receive : ${formatRupiah(receiveAmount.decimal)}\n${diffAmount.number == 0  && "Amount Diff : "+formatRupiah(amountDiff)+"\nAmount Difference Reason : "+amountDiffReason}\nPayment Type : ${paymentType}\nAmount Receive Date : ${new Date(amountReceiveDate).toLocaleDateString("id-ID")}\nAmount Receive Note : ${amountReceiveNote}\nCreated By : ${user?.Name}`,
+            CreatedBy: createdById ?? null,
+          },
+        });
+
+        await tx.casenotes.create({
+          data: {
+            CaseID: caseId,
+            LogType: "NotesLog",
+            ActionType: "Action Plan",
+            Template: "",
+            VisibleExternally: true,
+            MinutesSpent: 0,
+            Note: amountReceiveNote,
+            CreatedBy: createdById ?? null,
+          },
+        });
+    
+        await tx.actionLog.create({
+          data: {
+            CaseID_toActionLog: {
+              connect: { CaseID: caseId },
+            },
+            ReferenceId: invoiceNo,
+            model: "Invoice Log",
+            dataOld: "Invoice",
+            dataNew: "Invoice",
+            changedByUser: createdById
+              ? {
+                  connect: { IDUser: createdById },
+                }
+              : undefined,
+            logDescription: `New Invoice ${invoiceNo}`,
+          },
+          include: includeChangedBy,
+        });
+
+        return invoice
+      
+    })
+
+
+
+
+
+
 
     return NextResponse.json(
       {
         success: true,
         message: "Invoice berhasil dibuat.",
-        data: mapInvoicePayload(invoice, invoice.quotation),
+        data: mapInvoicePayload(result, result.quotation),
       },
       { status: 201 }
     );

--- a/next-api/src/app/api/invoice-information/route.js
+++ b/next-api/src/app/api/invoice-information/route.js
@@ -1,0 +1,297 @@
+import { NextResponse } from "next/server";
+import prisma from "../../../../prisma/client";
+import { generateID } from "@/utils/generateID";
+import { parseDate, toBooleanFlag } from "../quotation-information/helpers";
+import {
+  decimalToNumber,
+  mapInvoicePayload,
+  normaliseDecimalInput,
+  normaliseReason,
+} from "./helpers";
+
+const INVOICE_PREFIX = "INV-";
+
+const collectLineItemIds = (caseRecord) => {
+  if (!caseRecord) return [];
+  const ids = new Set();
+  caseRecord.workorder?.forEach((wo) => {
+    wo.materialorder?.forEach((mo) => {
+      mo.materialorderlineitems?.forEach((line) => {
+        if (line.LineItemID !== null && line.LineItemID !== undefined) {
+          ids.add(line.LineItemID);
+        }
+      });
+    });
+  });
+  return Array.from(ids);
+};
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const invoiceNo = searchParams.get("invoiceNo");
+    const quotationNo = searchParams.get("quotationNo");
+    const caseId = searchParams.get("caseId");
+
+    if (!invoiceNo && !quotationNo && !caseId) {
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            "Parameter pencarian tidak ditemukan. Gunakan invoiceNo, quotationNo, atau caseId.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (invoiceNo) {
+      const invoice = await prisma.invoicetable.findUnique({
+        where: { InvoiceNo: invoiceNo },
+        include: { quotation: true },
+      });
+
+      if (!invoice) {
+        return NextResponse.json(
+          { success: false, message: "Invoice tidak ditemukan." },
+          { status: 404 }
+        );
+      }
+
+      return NextResponse.json({
+        success: true,
+        data: mapInvoicePayload(invoice, invoice.quotation),
+      });
+    }
+
+    if (quotationNo) {
+      const quotation = await prisma.quotationtable.findUnique({
+        where: { QuotationNo: quotationNo },
+        include: {
+          invoicetable: {
+            orderBy: { AmountReceiveDate: "desc" },
+          },
+        },
+      });
+
+      if (!quotation) {
+        return NextResponse.json(
+          { success: false, message: "Quotation tidak ditemukan." },
+          { status: 404 }
+        );
+      }
+
+      const invoiceRecord = quotation.invoicetable?.[0] ?? null;
+
+      return NextResponse.json({
+        success: true,
+        data: mapInvoicePayload(invoiceRecord, quotation),
+      });
+    }
+
+    const caseRecord = await prisma.caseinformation.findUnique({
+      where: { CaseID: caseId },
+      select: {
+        CaseID: true,
+        workorder: {
+          select: {
+            materialorder: {
+              select: {
+                materialorderlineitems: {
+                  select: { LineItemID: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!caseRecord) {
+      return NextResponse.json(
+        { success: false, message: "Case tidak ditemukan." },
+        { status: 404 }
+      );
+    }
+
+    const lineItemIds = collectLineItemIds(caseRecord);
+
+    if (lineItemIds.length === 0) {
+      return NextResponse.json({ success: true, data: null });
+    }
+
+    const quotation = await prisma.quotationtable.findFirst({
+      where: {
+        quotation_lineitem: {
+          some: { LineItemID: { in: lineItemIds } },
+        },
+      },
+      orderBy: {
+        QuotationDate: "desc",
+      },
+      include: {
+        invoicetable: {
+          orderBy: { AmountReceiveDate: "desc" },
+        },
+      },
+    });
+
+    if (!quotation) {
+      return NextResponse.json({ success: true, data: null });
+    }
+
+    const invoiceRecord = quotation.invoicetable?.[0] ?? null;
+
+    return NextResponse.json({
+      success: true,
+      data: mapInvoicePayload(invoiceRecord, quotation),
+    });
+  } catch (error) {
+    console.error("Error fetching invoice:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: "Gagal mengambil data invoice.",
+        error: error.message,
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const {
+      quotationNo,
+      amountReceive,
+      amountDiff,
+      amountDiffReason,
+      paymentType,
+      amountReceiveDate,
+      amountReceiveNote,
+      sendWa,
+      sendEmail,
+      sendInvoice,
+      sendErf,
+      createdBy,
+    } = body;
+
+    if (!quotationNo) {
+      return NextResponse.json(
+        { success: false, message: "QuotationNo wajib diisi." },
+        { status: 400 }
+      );
+    }
+
+    const createdById = Number.parseInt(createdBy, 10);
+    if (!Number.isInteger(createdById)) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "CreatedBy tidak valid.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const quotation = await prisma.quotationtable.findUnique({
+      where: { QuotationNo: quotationNo },
+    });
+
+    if (!quotation) {
+      return NextResponse.json(
+        { success: false, message: "Quotation tidak ditemukan." },
+        { status: 404 }
+      );
+    }
+
+    const existingInvoice = await prisma.invoicetable.findFirst({
+      where: { QuotationNo: quotationNo },
+    });
+
+    if (existingInvoice) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Quotation ini sudah memiliki invoice.",
+        },
+        { status: 409 }
+      );
+    }
+
+    const receiveAmount = normaliseDecimalInput(amountReceive, {
+      fieldName: "Amount receive",
+    });
+
+    let diffAmount;
+    if (amountDiff !== undefined && amountDiff !== null && amountDiff !== "") {
+      diffAmount = normaliseDecimalInput(amountDiff, {
+        fieldName: "Amount difference",
+        allowNegative: true,
+      });
+    } else {
+      const grandTotalNumber = decimalToNumber(quotation.GrandTotal) ?? 0;
+      diffAmount = normaliseDecimalInput(grandTotalNumber - receiveAmount.number, {
+        fieldName: "Amount difference",
+        allowNegative: true,
+        defaultValue: 0,
+      });
+    }
+
+    const reason = normaliseReason(amountDiffReason);
+    if (diffAmount.number !== 0 && !reason) {
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            "Amount difference reason wajib diisi ketika terdapat selisih.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const invoiceNo = await generateID(
+      INVOICE_PREFIX,
+      "invoicetable",
+      "InvoiceNo"
+    );
+
+    const invoice = await prisma.invoicetable.create({
+      data: {
+        InvoiceNo: invoiceNo,
+        QuotationNo: quotationNo,
+        AmountReceive: receiveAmount.decimal,
+        AmountDiff: diffAmount.decimal,
+        AmountDiffReason: reason,
+        PaymentType: paymentType?.trim() || null,
+        AmountReceiveDate: parseDate(amountReceiveDate) ?? new Date(),
+        AmountReceiveNote: amountReceiveNote?.trim() || null,
+        SendWa: Boolean(toBooleanFlag(sendWa)),
+        SendEmail: Boolean(toBooleanFlag(sendEmail)),
+        SendInvoice: Boolean(toBooleanFlag(sendInvoice)),
+        SendERF: Boolean(toBooleanFlag(sendErf)),
+        CreatedBy: createdById,
+      },
+      include: { quotation: true },
+    });
+
+    return NextResponse.json(
+      {
+        success: true,
+        message: "Invoice berhasil dibuat.",
+        data: mapInvoicePayload(invoice, invoice.quotation),
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error creating invoice:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: "Gagal membuat invoice.",
+        error: error.message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
+++ b/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
@@ -307,8 +307,13 @@ export async function PATCH(request, { params }) {
           }),
         ),
       );
+      const rejectedLineItemIds = normalizedLineItems
+        .filter((item) => !item.approved)
+        .map((item) => item.lineItemId);
+      
 
       if (decisionValue === 'Rejected') {
+        
         await tx.materialorderlineitems.updateMany({
           where: {
             LineItemID: {
@@ -327,6 +332,29 @@ export async function PATCH(request, { params }) {
             }
           },
           data:{
+            OrderStatus: 'Cancelled'
+          }
+        })
+      } else if(rejectedLineItemIds.length > 0){
+        await tx.materialorderlineitems.updateMany({
+          where: {
+            LineItemID: { in: rejectedLineItemIds },
+          },
+          data:{
+            Status: 'Cancelled'
+          }
+        })
+
+        await tx.materialorder.updateMany({
+          where:{
+            MOID: {
+              in: relatedLineItems
+                .filter((item) => rejectedLineItemIds.includes(item.LineItemID))
+                .map((item) => item.materialorder?.MOID)
+                .filter((moid) => moid != null),
+            }
+          },
+          data: {
             OrderStatus: 'Cancelled'
           }
         })

--- a/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
+++ b/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
@@ -370,6 +370,11 @@ export async function PATCH(request, { params }) {
         });
       }
 
+      /**
+       * NOTE : THIS TEMPORARY ADAPTABLE TABLE FUNCTION NOT WORKING
+       * FIND OUT WHY
+       * THE PRICE WAS NOT UPDATED
+       */
       await Promise.all(
         normalizedLineItems.map((item) =>
           tx.materialorderlineitems.update({

--- a/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
+++ b/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
@@ -112,8 +112,31 @@ export async function PATCH(request, { params }) {
 
     const relatedLineItems = await prisma.materialorderlineitems.findMany({
       where: { LineItemID: { in: uniqueLineItemIds } },
-      select: { LineItemID: true, Quantity: true },
+      select: {
+        LineItemID: true,
+        Quantity: true,
+        materialorder: {
+          select: {
+            MOID: true,
+            workorder: {
+              select: {
+                CaseID: true,
+                WOID: true,
+                owner: {
+                  select: {
+                    IDUser: true,
+                    Name: true,
+                    Role: true,
+                    Username: true
+                  }
+                }
+              }
+            }
+          },
+        },
+      },
     });
+
 
     if (relatedLineItems.length !== uniqueLineItemIds.length) {
       return NextResponse.json(
@@ -124,6 +147,8 @@ export async function PATCH(request, { params }) {
         { status: 404 },
       );
     }
+
+    
 
     const quantityMap = new Map(
       relatedLineItems.map((item) => [item.LineItemID, item.Quantity ?? 1]),
@@ -182,6 +207,8 @@ export async function PATCH(request, { params }) {
       targetStatusCase = 'Pending_Quote';
     }
 
+    
+
     const includeChangedBy = {
       changedByUser: {
           select: {
@@ -191,12 +218,43 @@ export async function PATCH(request, { params }) {
           },
       },
     };
+    
 
     const quotation = await prisma.$transaction(async (tx) => {
       const existingLineItems = await tx.quotation_lineitem.findMany({
         where: { QuotationNo },
         select: { id: true, LineItemID: true },
       });
+
+      const caseInfo = await prisma.caseinformation.findUnique({
+        where: { CaseID: caseId },
+        select: {
+            CaseStatus: true,
+            Owner: true,
+            CreatedBy: true,
+            ownerUser: {
+                select: {
+                    IDUser: true,
+                    Name: true,
+                },
+            },
+        }
+      })
+
+      const newOwnerUser = userAssign !== null
+        ? await prisma.user.findUnique({
+            where: { IDUser: userAssign },
+            select: {
+                IDUser: true,
+                Name: true,
+            },
+        })
+        : null;
+
+      const oldOwnerName = caseInfo.ownerUser?.Name ?? (caseInfo.Owner != null ? String(caseInfo.Owner) : "-");
+      const newOwnerName = newOwnerUser?.Name ?? (userAssign != null ? String(userAssign) : "-");
+
+      
 
       const updated = await tx.quotationtable.update({
         where: { QuotationNo },
@@ -270,24 +328,24 @@ export async function PATCH(request, { params }) {
       if(targetStatusCase !== "Pending_Quote"){
         caseUpdateData.Owner = userAssign
 
-        // await tx.ActionLog.create({
-        //   data: {
-        //     CaseID_toActionLog: {
-        //       connect: { CaseID: caseId },
-        //     },
-        //     ReferenceId: QuotationNo,
-        //     model: "Quotation Log",
-        //     dataOld: status,
-        //     dataNew: targetStatusCase,
-        //     changedByUser: createdBy
-        //       ? {
-        //           connect: { IDUser: createdBy },
-        //         }
-        //       : undefined,
-        //     logDescription: `Edit: change status from ${status} to ${targetStatusCase}`,
-        //   },
-        //   include: includeChangedBy,
-        // });
+        await tx.ActionLog.create({
+          data: {
+            CaseID_toActionLog: {
+              connect: { CaseID: caseId },
+            },
+            ReferenceId: caseId,
+            model: "CaseOwner",
+            dataOld: oldOwnerName,
+            dataNew: newOwnerName,
+            changedByUser: createdBy
+              ? {
+                  connect: { IDUser: createdBy },
+                }
+              : undefined,
+            logDescription: `Edit: change owner from ${oldOwnerName} to ${newOwnerName}`,
+          },
+          include: includeChangedBy,
+        });
       }
       await tx.caseinformation.update({
         where: { CaseID: caseId },

--- a/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
+++ b/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
@@ -96,6 +96,7 @@ export async function PATCH(request, { params }) {
         { status: 400 },
       );
     }
+    
 
     const lineItemIds = normalizedLineItems.map((item) => item.lineItemId);
     const uniqueLineItemIds = [...new Set(lineItemIds)];
@@ -201,8 +202,8 @@ export async function PATCH(request, { params }) {
         Approved: 'Quote_Approved',
         Rejected: 'Quote_Rejected',
       };
-
       targetStatusCase = statusMap[decisionValue] || 'Quote_Approved';
+
     } else {
       targetStatusCase = 'Pending_Quote';
     }
@@ -218,6 +219,8 @@ export async function PATCH(request, { params }) {
           },
       },
     };
+    
+    // return console.log(relatedLineItems)
     
 
     const quotation = await prisma.$transaction(async (tx) => {
@@ -304,6 +307,30 @@ export async function PATCH(request, { params }) {
           }),
         ),
       );
+
+      if (decisionValue === 'Rejected') {
+        await tx.materialorderlineitems.updateMany({
+          where: {
+            LineItemID: {
+              in: normalizedLineItems.map((item) => item.lineItemId),
+            },
+          },
+          data: {
+            Status: 'Cancelled',
+          },
+        });
+
+        await tx.materialorder.updateMany({
+          where: {
+            MOID: {
+              in: relatedLineItems.map((item) => item.materialorder?.MOID),
+            }
+          },
+          data:{
+            OrderStatus: 'Cancelled'
+          }
+        })
+      }
 
       const obsoleteIds = existingLineItems
         .filter((item) => !incomingIds.has(item.LineItemID))

--- a/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
+++ b/next-api/src/app/api/quotation-information/[QuotationNo]/route.js
@@ -365,6 +365,20 @@ export async function PATCH(request, { params }) {
         },
       });
 
+      if(quotationNote !== null) {
+        await tx.casenotes.create({
+          data: {
+            CaseID: caseId,
+            LogType: "System Info",
+            ActionType: "Quotation Request",
+            Template: "",
+            VisibleExternally: true,
+            MinutesSpent: 0,
+            Note: quotationNote,
+            CreatedBy: createdBy ?? Number.parseInt(userAssign, 10) ?? null,
+          },
+        });
+      }
       await tx.ActionLog.create({
         data: {
           CaseID_toActionLog: {

--- a/next-api/src/app/api/quotation-information/helpers.js
+++ b/next-api/src/app/api/quotation-information/helpers.js
@@ -57,7 +57,7 @@ export const normalizeLineItemPayload = (raw, requireApproval) => {
   return {
     lineItemId,
     price: new Prisma.Decimal(priceNumber),
-    approved: partApproved ?? false,
+    approved: partApproved ?? true,
   };
 };
 

--- a/next-api/src/app/api/service-log/create-order/route.js
+++ b/next-api/src/app/api/service-log/create-order/route.js
@@ -265,7 +265,7 @@ export async function POST(request) {
             }
 
             const caseUpdateData = { CaseStatus: "PartRequest" };
-            if(isOutWarranty) caseUpdateData.CaseStatus = "Quotation_Requested"
+            if(isOutWarranty) caseUpdateData.CaseStatus = "Quote_Requested"
             if (assignApoId !== null) {
                 caseUpdateData.Owner = assignApoId;
             }

--- a/next-api/src/app/api/service-log/create-order/route.js
+++ b/next-api/src/app/api/service-log/create-order/route.js
@@ -179,9 +179,11 @@ export async function POST(request) {
                     },
                 });
 
+                const noteWarranty = isOutWarranty ? 'Request Quotation' : "Order"
+
                 const noteLines = [
-                    "[NOTICE] Order Part",
-                    `Order Part : ${part.PartNumber ?? "-"} - ${part.PartDescription ?? "-"}`
+                    "[NOTICE] "+noteWarranty+" Part",
+                    `${noteWarranty} Part : ${part.PartNumber ?? "-"} - ${part.PartDescription ?? "-"}`
                 ];
 
                 if (isOutWarranty && part.Price !== undefined && part.Price !== null && part.Price !== "") {
@@ -206,7 +208,8 @@ export async function POST(request) {
                         ? String(materialOrderOwnerID)
                         : "-";
 
-                noteLines.push(`Requested to APO : ${requestedRecipient}`);
+                const targetQuotation = isOutWarranty ? "CM" : "APO"
+                noteLines.push(`Requested to ${targetQuotation} : ${requestedRecipient}`);
 
                 const noteText = noteLines.join("\n");
 
@@ -264,8 +267,12 @@ export async function POST(request) {
                 });
             }
 
+            
+            console.log("IS OUT WARRANRY ", isOutWarranty)
             const caseUpdateData = { CaseStatus: "PartRequest" };
             if(isOutWarranty) caseUpdateData.CaseStatus = "Quote_Requested"
+
+            console.log("IS OUT WARRANRY ", caseUpdateData)
             if (assignApoId !== null) {
                 caseUpdateData.Owner = assignApoId;
             }
@@ -304,13 +311,13 @@ export async function POST(request) {
                     },
                     model: "Case",
                     dataOld: previousCaseStatus,
-                    dataNew: "Part Request",
+                    dataNew: caseUpdateData.CaseStatus,
                     changedByUser: ownerIdNumber
                         ? {
                               connect: { IDUser: ownerIdNumber },
                           }
                         : undefined,
-                    logDescription: `Edit: change status from ${previousCaseStatus} to Part Request`,
+                    logDescription: `Edit: change status from ${previousCaseStatus} to ${caseUpdateData.CaseStatus}`,
                 },
                 include: includeChangedBy,
             });

--- a/next-api/src/app/api/work-order/[WOID]/route.js
+++ b/next-api/src/app/api/work-order/[WOID]/route.js
@@ -99,6 +99,8 @@ export async function PATCH(request, { params }) {
         DefectDesc,
         RepairAction,
         ServiceTypeId,
+        CancelReason,
+        IsCancel
         } = body;
 
         // if (
@@ -163,7 +165,9 @@ export async function PATCH(request, { params }) {
             CEAnalysis: v => v,
             DefectDesc: v => v,
             RepairAction: v => v,
-            ServiceTypeId: v => v
+            ServiceTypeId: v => v,
+            CancelReason: v => v,
+            IsCancel: v => v
           };
           
           

--- a/test-vite/src/components/model/InvoiceModal.jsx
+++ b/test-vite/src/components/model/InvoiceModal.jsx
@@ -1,0 +1,22 @@
+import { useState, useEffect, useMemo } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "../ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "../ui/card";
+import CaseField from "../CaseField";
+import { Textarea } from "../ui/textarea";
+import { debounce } from "lodash";
+import { SearchCommandBlock } from "../sc-select";
+import ApiCustomer from "@/api";
+import { toast } from "sonner";
+
+
+export default InvoiceDialog;

--- a/test-vite/src/components/model/InvoiceModal.jsx
+++ b/test-vite/src/components/model/InvoiceModal.jsx
@@ -1,22 +1,439 @@
-import { useState, useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogClose,
 } from "@/components/ui/dialog";
 import { Button } from "../ui/button";
 import { Input } from "@/components/ui/input";
-import { Card, CardContent } from "../ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../ui/card";
 import CaseField from "../CaseField";
 import { Textarea } from "../ui/textarea";
-import { debounce } from "lodash";
 import { SearchCommandBlock } from "../sc-select";
-import ApiCustomer from "@/api";
-import { toast } from "sonner";
+import { Checkbox } from "../ui/checkbox";
+import { formatAccountingRupiah, formatDateForInput } from "@/lib/utils";
 
+const AMOUNT_DIFF_REASON_OPTIONS = [
+  "Cancellation Fee (part mahal)",
+  "Discount",
+  "Free absorb by HP",
+  "Free cancel (Onsite)",
+  "Free EOS/Not support ID",
+  "Free harga tidak ekonomis",
+  "Free rerepair",
+  "Free unit Nexgen",
+  "Free void warranty",
+  "Partial part",
+  "PPh23 / VAT",
+  "Service Fee / Labor only",
+  "Warranty approved",
+];
+
+const buildInitialForm = (invoice, quotation) => {
+  const today = formatDateForInput(new Date().toISOString());
+  const quotationNo = quotation?.quotationNo ?? "";
+  const grandTotalRaw = quotation?.grandTotal ?? "";
+  const receiveRaw = invoice?.amountReceive ?? (grandTotalRaw || "");
+
+  const grandTotalNumber = Number(grandTotalRaw || 0);
+  const amountReceiveNumber = Number(receiveRaw || 0);
+  const defaultDiff =
+    grandTotalRaw && receiveRaw !== ""
+      ? (grandTotalNumber - amountReceiveNumber).toFixed(2)
+      : "0";
+
+  return {
+    invoiceNo: invoice?.invoiceNo ?? "",
+    quotationNo,
+    amountReceive: receiveRaw ?? "",
+    amountDiff: invoice?.amountDiff ?? defaultDiff,
+    amountDiffReason: invoice?.amountDiffReason ?? "",
+    paymentType: invoice?.paymentType ?? "",
+    amountReceiveDate: invoice?.amountReceiveDate
+      ? formatDateForInput(invoice.amountReceiveDate)
+      : today,
+    amountReceiveNote: invoice?.amountReceiveNote ?? "",
+    sendWa: invoice?.sendWa ?? false,
+    sendEmail: invoice?.sendEmail ?? false,
+    sendInvoice: invoice?.sendInvoice ?? false,
+    sendErf: invoice?.sendErf ?? false,
+  };
+};
+
+const InvoiceDialog = ({
+  open,
+  onOpenChange,
+  quotation,
+  invoice,
+  loading,
+  submitting,
+  onSubmit,
+}) => {
+  const [step, setStep] = useState("form");
+  const [form, setForm] = useState(() => buildInitialForm(invoice, quotation));
+  const [errors, setErrors] = useState({});
+
+  const grandTotalNumber = useMemo(() => {
+    if (!quotation?.grandTotal) return 0;
+    const parsed = Number(quotation.grandTotal);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }, [quotation]);
+
+  useEffect(() => {
+    if (!open) {
+      setStep("form");
+      setErrors({});
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setForm(buildInitialForm(invoice, quotation));
+    setErrors({});
+    setStep("form");
+  }, [invoice, quotation]);
+
+  const handleChange = (field, value) => {
+    setForm((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleAmountReceiveChange = (value) => {
+    setForm((prev) => {
+      const next = { ...prev, amountReceive: value };
+      const parsed = Number(value);
+      if (!Number.isNaN(parsed)) {
+        const diff = (grandTotalNumber - parsed).toFixed(2);
+        next.amountDiff = diff;
+        if (Math.abs(Number(diff)) < 0.0001) {
+          next.amountDiffReason = "";
+        }
+      }
+      return next;
+    });
+  };
+
+  const validateForm = () => {
+    const nextErrors = {};
+
+    if (!quotation?.quotationNo) {
+      nextErrors.quotationNo = "Quotation belum tersedia.";
+    }
+
+    if (
+      form.amountReceive === "" ||
+      Number.isNaN(Number(form.amountReceive))
+    ) {
+      nextErrors.amountReceive = "Amount receive wajib diisi dengan angka.";
+    }
+
+    if (
+      Number(form.amountDiff || 0) !== 0 &&
+      (!form.amountDiffReason || form.amountDiffReason.trim() === "")
+    ) {
+      nextErrors.amountDiffReason =
+        "Pilih alasan ketika terdapat selisih nominal.";
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleNext = () => {
+    if (validateForm()) {
+      setStep("confirm");
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!onSubmit) return;
+    const payload = {
+      invoiceNo: form.invoiceNo || undefined,
+      quotationNo: form.quotationNo,
+      amountReceive: form.amountReceive,
+      amountDiff: form.amountDiff,
+      amountDiffReason: form.amountDiffReason,
+      paymentType: form.paymentType,
+      amountReceiveDate: form.amountReceiveDate,
+      amountReceiveNote: form.amountReceiveNote,
+      sendWa: form.sendWa,
+      sendEmail: form.sendEmail,
+      sendInvoice: form.sendInvoice,
+      sendErf: form.sendErf,
+    };
+    onSubmit(payload);
+  };
+
+  const renderLoading = () => (
+    <div className="flex min-h-[200px] items-center justify-center text-sm text-muted-foreground">
+      Mengambil data invoice...
+    </div>
+  );
+
+  const renderEmptyQuotation = () => (
+    <div className="flex min-h-[200px] flex-col items-center justify-center text-center text-sm text-muted-foreground">
+      <p>Belum ada quotation untuk case ini.</p>
+      <p className="text-xs">Buat quotation terlebih dahulu sebelum membuat invoice.</p>
+    </div>
+  );
+
+  const renderForm = () => (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Ringkasan Quotation</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <CaseField label="Quotation No" lock>
+            <Input value={quotation?.quotationNo || "-"} readOnly />
+          </CaseField>
+          <CaseField label="Subtotal" lock>
+            <Input
+              value={formatAccountingRupiah(quotation?.subtotal)}
+              readOnly
+            />
+          </CaseField>
+          <CaseField label="Grand Total (After VAT)" lock>
+            <Input
+              value={formatAccountingRupiah(quotation?.grandTotal)}
+              readOnly
+            />
+          </CaseField>
+          <CaseField label="VAT Amount" lock>
+            <Input
+              value={formatAccountingRupiah(quotation?.vatAmount)}
+              readOnly
+            />
+          </CaseField>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Detail Invoice</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <CaseField label="Amount Receive *" lock={false}>
+            <div className="space-y-1">
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.amountReceive}
+                onChange={(e) => handleAmountReceiveChange(e.target.value)}
+              />
+              {errors.amountReceive && (
+                <p className="text-xs text-red-500">{errors.amountReceive}</p>
+              )}
+            </div>
+          </CaseField>
+
+          <CaseField label="Payment Type">
+            <Input
+              value={form.paymentType}
+              onChange={(e) => handleChange("paymentType", e.target.value)}
+              placeholder="Transfer / Cash / VA"
+            />
+          </CaseField>
+
+          <CaseField label="Tanggal Terima">
+            <Input
+              type="date"
+              value={form.amountReceiveDate}
+              onChange={(e) => handleChange("amountReceiveDate", e.target.value)}
+            />
+          </CaseField>
+
+          <CaseField label="Amount Difference" lock>
+            <Input
+              value={form.amountDiff}
+              onChange={(e) => handleChange("amountDiff", e.target.value)}
+            />
+          </CaseField>
+
+          {Number(form.amountDiff) !== 0 && (
+            <CaseField label="Alasan Amount Difference">
+              <div className="space-y-1">
+                <SearchCommandBlock
+                  value={form.amountDiffReason}
+                  placeholder="Pilih alasan..."
+                  onChange={(value) => handleChange("amountDiffReason", value)}
+                  options={AMOUNT_DIFF_REASON_OPTIONS.map((reason) => ({
+                    label: reason,
+                    value: reason,
+                  }))}
+                />
+                {errors.amountDiffReason && (
+                  <p className="text-xs text-red-500">
+                    {errors.amountDiffReason}
+                  </p>
+                )}
+              </div>
+            </CaseField>
+          )}
+
+          <CaseField label="Catatan">
+            <Textarea
+              value={form.amountReceiveNote}
+              onChange={(e) =>
+                handleChange("amountReceiveNote", e.target.value)
+              }
+              placeholder="Catatan tambahan terkait invoice"
+              rows={3}
+            />
+          </CaseField>
+
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <Checkbox
+                checked={form.sendInvoice}
+                onCheckedChange={(checked) =>
+                  handleChange("sendInvoice", Boolean(checked))
+                }
+              />
+              <span>Kirim Invoice</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <Checkbox
+                checked={form.sendWa}
+                onCheckedChange={(checked) =>
+                  handleChange("sendWa", Boolean(checked))
+                }
+              />
+              <span>Kirim WhatsApp</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <Checkbox
+                checked={form.sendEmail}
+                onCheckedChange={(checked) =>
+                  handleChange("sendEmail", Boolean(checked))
+                }
+              />
+              <span>Kirim Email</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <Checkbox
+                checked={form.sendErf}
+                onCheckedChange={(checked) =>
+                  handleChange("sendErf", Boolean(checked))
+                }
+              />
+              <span>Kirim ERF</span>
+            </label>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+
+  const renderConfirmation = () => (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Pastikan data berikut sudah benar sebelum disimpan.
+      </p>
+      <div className="space-y-2 rounded-md border bg-muted/50 p-4 text-sm">
+        <p>
+          <strong>Quotation No:</strong> {quotation?.quotationNo || "-"}
+        </p>
+        <p>
+          <strong>Grand Total:</strong>{" "}
+          {formatAccountingRupiah(quotation?.grandTotal)}
+        </p>
+        <p>
+          <strong>Amount Receive:</strong>{" "}
+          {formatAccountingRupiah(form.amountReceive)}
+        </p>
+        <p>
+          <strong>Amount Difference:</strong>{" "}
+          {formatAccountingRupiah(form.amountDiff)}
+        </p>
+        {Number(form.amountDiff || 0) !== 0 && (
+          <p>
+            <strong>Alasan Selisih:</strong> {form.amountDiffReason || "-"}
+          </p>
+        )}
+        <p>
+          <strong>Payment Type:</strong> {form.paymentType || "-"}
+        </p>
+        <p>
+          <strong>Tanggal Terima:</strong> {form.amountReceiveDate || "-"}
+        </p>
+        {form.amountReceiveNote && (
+          <p>
+            <strong>Catatan:</strong> {form.amountReceiveNote}
+          </p>
+        )}
+        <p>
+          <strong>Notifikasi:</strong>{" "}
+          {[
+            form.sendInvoice && "Invoice",
+            form.sendWa && "WA",
+            form.sendEmail && "Email",
+            form.sendErf && "ERF",
+          ]
+            .filter(Boolean)
+            .join(", ") || "-"}
+        </p>
+      </div>
+    </div>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{form.invoiceNo ? "Perbarui Invoice" : "Buat Invoice"}</DialogTitle>
+          <DialogDescription>
+            Isi informasi invoice sebelum case ditutup.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading
+          ? renderLoading()
+          : !quotation
+            ? renderEmptyQuotation()
+            : step === "form"
+              ? renderForm()
+              : renderConfirmation()}
+
+        {!loading && quotation && (
+          <DialogFooter className="mt-6">
+            {step === "form" ? (
+              <>
+                <DialogClose asChild>
+                  <Button variant="secondary">Batal</Button>
+                </DialogClose>
+                <Button onClick={handleNext}>Lanjut</Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="secondary"
+                  onClick={() => setStep("form")}
+                  disabled={submitting}
+                >
+                  Kembali
+                </Button>
+                <Button onClick={handleConfirm} disabled={submitting}>
+                  {submitting ? "Menyimpan..." : "Simpan Invoice"}
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 export default InvoiceDialog;

--- a/test-vite/src/components/model/InvoiceModal.jsx
+++ b/test-vite/src/components/model/InvoiceModal.jsx
@@ -256,8 +256,8 @@ const InvoiceDialog = ({
 
           <CaseField label="Amount Difference" lock>
             <Input
-              value={form.amountDiff}
-              onChange={(e) => handleChange("amountDiff", e.target.value)}
+              value={formatAccountingRupiah(form.amountDiff)}
+              readOnly
             />
           </CaseField>
 

--- a/test-vite/src/components/model/QuotationModal.jsx
+++ b/test-vite/src/components/model/QuotationModal.jsx
@@ -221,7 +221,6 @@ const QuotationDialog = ({
     setFieldErrors({});
     setLineErrors({});
     fetchUserAssign('apo');
-    {console.log("KOntol",form, initialData)}
   }, [defaultFormState]);
 
   const filteredUserAssign = roleAssign.filter(
@@ -242,6 +241,8 @@ const QuotationDialog = ({
     syncLineItems(materialItems);
   }, [syncLineItems]);
 
+
+
   useEffect(() => {
     setForm((prev) => ({
       ...prev,
@@ -252,6 +253,26 @@ const QuotationDialog = ({
       quoteDecision: isPendingQuote ? prev.quoteDecision : "",
     }));
   }, [isPendingQuote, isQuoteRequested]);
+
+  useEffect(() =>{
+    if(form.quoteDecision === "reject") {
+      setForm((prevForm) => ({
+        ...prevForm,
+        lineItems: prevForm.lineItems.map((item) => ({
+          ...item,
+          partApproved: "no",
+        })),
+      }));
+    }else{
+      setForm((prevForm) => ({
+        ...prevForm,
+        lineItems: prevForm.lineItems.map((item) => ({
+          ...item,
+          partApproved: "yes",
+        })),
+      }));
+    }
+  }, [form.quoteDecision])
 
   const handleFieldChange = (field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -346,20 +367,21 @@ const QuotationDialog = ({
         ? "Approved"
         : "Rejected"
       : null;
-
-    const payload = {
-      quotationNo: existingQuotationNo,
-      quotationType: form.quotationType,
-      vatValue: form.vatValue,
-      quotationNote: form.quotationNote,
-      laborFee: form.laborFee,
-      quotationDate: form.quotationDate,
-      quoteApproveDate: isPendingQuote ? form.quoteApproveDate : null,
-      useNewQuotationNo: form.useNewQuotationNo,
-      sendWa: form.sendWa,
-      sendEmail: form.sendEmail,
-      quoteDecision: quoteDecisionValue,
-      userAssign: form.userAssign ?? createdBy.id,
+    
+      
+      const payload = {
+        quotationNo: existingQuotationNo,
+        quotationType: form.quotationType,
+        vatValue: form.vatValue,
+        quotationNote: form.quotationNote,
+        laborFee: form.laborFee,
+        quotationDate: form.quotationDate,
+        quoteApproveDate: isPendingQuote ? form.quoteApproveDate : null,
+        useNewQuotationNo: form.useNewQuotationNo,
+        sendWa: form.sendWa,
+        sendEmail: form.sendEmail,
+        quoteDecision: quoteDecisionValue,
+        userAssign: form.userAssign ?? createdBy.id,
       lineItems: form.lineItems.map((item) => ({
         lineItemId: item.internalId,
         price: item.price,
@@ -370,11 +392,13 @@ const QuotationDialog = ({
       caseId,
       createdBy: createdBy.id
     };
-
+    
+    // console.log("ON PAYLOAD KONT", form)
+    // return console.log("ON PAYLOAD KONT", payload)
+    
     // if(quoteDecisionValue === 'Rejected') pa
     onSubmit?.(payload);
   };
-  console.log("Form ",form)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/test-vite/src/components/model/QuotationModal.jsx
+++ b/test-vite/src/components/model/QuotationModal.jsx
@@ -96,7 +96,7 @@ const normaliseLineItems = (items = [], prevItems = []) => {
       item?.partApproved ??
       item?.Approved ??
       previous.partApproved ??
-      "";
+      "yes";
 
     if (partApprovedValue === null || partApprovedValue === undefined) {
       partApprovedValue = "";
@@ -194,7 +194,7 @@ export const QuotationDialog = ({
     return {
       quotationType: initialData.quotationType ?? "Simple",
       vatValue: initialData.vatValue ?? "",
-      quotationNote: initialData.quotationNote ?? "",
+      quotationNote: null,
       laborFee: initialData.laborFee ?? "",
       quotationDate,
       useNewQuotationNo:
@@ -373,6 +373,7 @@ export const QuotationDialog = ({
     // if(quoteDecisionValue === 'Rejected') pa
     onSubmit?.(payload);
   };
+  console.log("Form ",form)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -397,6 +398,22 @@ export const QuotationDialog = ({
           <Card className={'h-65'}>
             <CardContent className="grid grid-cols-1 gap-4 lg:grid-cols-2">
               <div className="grid grid-cols-4 gap-2">
+                
+                <CaseField
+                  label="Quotation Date"
+                  star
+                  className={'gap-0'}
+                  >
+                  <Input
+                    type="date"
+                    disabled={formDisabled}
+                    value={form.quotationDate}
+                    onChange={(e) => handleFieldChange("quotationDate", e.target.value)}
+                  />
+                  {fieldErrors.quotationDate && (
+                    <p className="text-xs text-red-500">{fieldErrors.quotationDate}</p>
+                  )}
+                </CaseField>
                 {isPendingQuote && (
                   <CaseField
                     label="Quote Approve Date"
@@ -423,7 +440,7 @@ export const QuotationDialog = ({
                   label="Quotation Type"
                   star
                   className={'gap-0'}
-                >
+                  >
                   <Select
                     disabled={formDisabled}
                     value={form.quotationType}
@@ -441,53 +458,11 @@ export const QuotationDialog = ({
                     <p className="text-xs text-red-500">{fieldErrors.quotationType}</p>
                   )}
                 </CaseField>
+
                 <CaseField
-                  label="Quotation Date"
-                  star
-                  className={'gap-0'}
-                >
-                  <Input
-                    type="date"
-                    disabled={formDisabled}
-                    value={form.quotationDate}
-                    onChange={(e) => handleFieldChange("quotationDate", e.target.value)}
-                  />
-                  {fieldErrors.quotationDate && (
-                    <p className="text-xs text-red-500">{fieldErrors.quotationDate}</p>
-                  )}
-                </CaseField>
-                
-                {isPendingQuote && (
-                  <CaseField
-                    label="Quotation Decision"
-                    star
-                    className={'gap-0'}
-                  >
-                    <Select
-                      disabled={formDisabled}
-                      value={form.quoteDecision}
-                      onValueChange={(value) => handleFieldChange("quoteDecision", value)}
-                    >
-                      <SelectTrigger className="w-full" disabled={formDisabled}>
-                        <SelectValue placeholder="Pilih keputusan" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="approve">Approve</SelectItem>
-                        <SelectItem value="reject">Reject</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    {fieldErrors.quoteDecision && (
-                      <p className="text-xs text-red-500">
-                        {fieldErrors.quoteDecision}
-                      </p>
-                    )}
-                  </CaseField>
-                )}
-                   <CaseField
                   label="Labor Fee"
                   star
-                  className={'gap-0 col-span-2 gap-x-5'}
-                  span={2}
+                  className={'gap-0'}
                 >
                   <Input
                     disabled={formDisabled}
@@ -522,6 +497,68 @@ export const QuotationDialog = ({
                     )}
                   </CaseField>
                 )}
+
+                {isPendingQuote && (
+                  <CaseField
+                    label="Quotation Decision"
+                    star
+                    className={'gap-0'}
+                  >
+                    <Select
+                      disabled={formDisabled}
+                      value={form.quoteDecision}
+                      onValueChange={(value) => handleFieldChange("quoteDecision", value)}
+                    >
+                      <SelectTrigger className="w-full" disabled={formDisabled}>
+                        <SelectValue placeholder="Pilih keputusan" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="approve">Approve</SelectItem>
+                        <SelectItem value="reject">Reject</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {fieldErrors.quoteDecision && (
+                      <p className="text-xs text-red-500">
+                        {fieldErrors.quoteDecision}
+                      </p>
+                    )}
+                  </CaseField>
+                )}
+                
+                {form.quoteDecision === "approve" && (
+                <CaseField
+                  label="Select APO"
+                  star={form.quoteDecision === "approve"}
+                  className="gap-0"
+                >
+                  <SearchCommandBlock 
+                    value={form.userAssign}
+                    onChange={(selectedID) =>{
+                      if(selectedID === null) {
+                        handleFieldChange("userAssign", value);
+                        return;
+                      }
+                      const selectedUser = filteredUserAssign.find(
+                        (user) => user.IDUser === selectedID
+                      );
+                      if (selectedUser) {
+                        handleFieldChange("userAssign", selectedUser.IDUser);
+                      }
+                    }}
+                    placeholder="--Select--"
+                    options={filteredUserAssign.map((user) =>({
+                      label: user.Name,
+                      value: user.IDUser,
+                    }))}
+                    renderLabel={(opt) => opt.label}
+                    getValue={(opt) => opt.value}
+                    className={'border-2 ring-1 ring-gray-200 bg-slate-100'}
+                  />
+                  {fieldErrors.userAssign && (
+                    <p className="text-xs text-red-500">{fieldErrors.userAssign}</p>
+                  )}
+                </CaseField>
+              )}
                 
               </div>
 

--- a/test-vite/src/components/model/QuotationModal.jsx
+++ b/test-vite/src/components/model/QuotationModal.jsx
@@ -370,6 +370,7 @@ export const QuotationDialog = ({
       createdBy: createdBy.id
     };
 
+    // if(quoteDecisionValue === 'Rejected') pa
     onSubmit?.(payload);
   };
 

--- a/test-vite/src/components/model/QuotationModal.jsx
+++ b/test-vite/src/components/model/QuotationModal.jsx
@@ -221,7 +221,8 @@ const QuotationDialog = ({
     setFieldErrors({});
     setLineErrors({});
     fetchUserAssign('apo');
-  }, []);
+    {console.log("KOntol",form, initialData)}
+  }, [defaultFormState]);
 
   const filteredUserAssign = roleAssign.filter(
     (user) => user.Role === "apo"
@@ -395,252 +396,205 @@ const QuotationDialog = ({
               Memuat data quotation...
             </div>
           )}
-          <Card className={'h-65'}>
-            <CardContent className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-              <div className="grid grid-cols-4 gap-2">
-                
-                <CaseField
-                  label="Quotation Date"
-                  star
-                  className={'gap-0'}
-                  >
-                  <Input
-                    type="date"
-                    disabled={formDisabled}
-                    value={form.quotationDate}
-                    onChange={(e) => handleFieldChange("quotationDate", e.target.value)}
-                  />
-                  {fieldErrors.quotationDate && (
-                    <p className="text-xs text-red-500">{fieldErrors.quotationDate}</p>
-                  )}
-                </CaseField>
-                {isPendingQuote && (
-                  <CaseField
-                    label="Quote Approve Date"
-                    star
-                    className={'gap-0'}
-                  >
-                    <Input
-                      type="date"
-                      disabled={formDisabled}
-                      value={form.quoteApproveDate}
-                      onChange={(e) =>
-                        handleFieldChange("quoteApproveDate", e.target.value)
-                      }
-                    />
-                    {fieldErrors.quoteApproveDate && (
-                      <p className="text-xs text-red-500">
-                        {fieldErrors.quoteApproveDate}
-                      </p>
-                    )}
-                  </CaseField>
-                )}
+           <Card>
+      <CardContent className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* LEFT SIDE */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {/* all your CaseFields on the left */}
+          <CaseField label="Quotation Date" star>
+            <Input
+              type="date"
+              disabled={formDisabled}
+              value={form.quotationDate}
+              onChange={(e) => handleFieldChange("quotationDate", e.target.value)}
+            />
+            {fieldErrors.quotationDate && (
+              <p className="text-xs text-red-500">{fieldErrors.quotationDate}</p>
+            )}
+          </CaseField>
 
-                <CaseField
-                  label="Quotation Type"
-                  star
-                  className={'gap-0'}
-                  >
-                  <Select
-                    disabled={formDisabled}
-                    value={form.quotationType}
-                    onValueChange={(value) => handleFieldChange("quotationType", value)}
-                  >
-                    <SelectTrigger className="w-full" disabled={formDisabled}>
-                      <SelectValue placeholder="Pilih tipe quotation" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="Simple">Simple</SelectItem>
-                      <SelectItem value="Standard">Standard</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  {fieldErrors.quotationType && (
-                    <p className="text-xs text-red-500">{fieldErrors.quotationType}</p>
-                  )}
-                </CaseField>
-
-                <CaseField
-                  label="Labor Fee"
-                  star
-                  className={'gap-0'}
-                >
-                  <Input
-                    disabled={formDisabled}
-                    value={form.laborFee}
-                    onChange={(e) => handleFieldChange("laborFee", e.target.value)}
-                    placeholder="Masukkan biaya labor"
-                    type="number"
-                    min="0"
-                  />
-                  {fieldErrors.laborFee && (
-                    <p className="text-xs text-red-500">{fieldErrors.laborFee}</p>
-                  )}
-                </CaseField>
-                                
-             
-                {form.quotationType === "Standard" && (
-                  <CaseField
-                    label="VAT Value (%)"
-                    star
-                    className={'gap-0'}
-                  >
-                    <Input
-                      disabled={formDisabled}
-                      value={form.vatValue}
-                      onChange={(e) => handleFieldChange("vatValue", e.target.value)}
-                      placeholder="Contoh: 10"
-                      type="number"
-                      min="0"
-                    />
-                    {fieldErrors.vatValue && (
-                      <p className="text-xs text-red-500">{fieldErrors.vatValue}</p>
-                    )}
-                  </CaseField>
-                )}
-
-                {isPendingQuote && (
-                  <CaseField
-                    label="Quotation Decision"
-                    star
-                    className={'gap-0'}
-                  >
-                    <Select
-                      disabled={formDisabled}
-                      value={form.quoteDecision}
-                      onValueChange={(value) => handleFieldChange("quoteDecision", value)}
-                    >
-                      <SelectTrigger className="w-full" disabled={formDisabled}>
-                        <SelectValue placeholder="pilih"/>
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="approve">Approve</SelectItem>
-                        <SelectItem value="reject">Reject</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    {fieldErrors.quoteDecision && (
-                      <p className="text-xs text-red-500">
-                        {fieldErrors.quoteDecision}
-                      </p>
-                    )}
-                  </CaseField>
-                )}
-                   <CaseField
-                  label="Labor Fee"
-                  star
-                  className={'gap-0 col-span-2 gap-x-5'}
-                  span={2}
-                >
-                  <Input
-                    disabled={formDisabled}
-                    value={form.laborFee}
-                    onChange={(e) => handleFieldChange("laborFee", e.target.value)}
-                    placeholder="Masukkan biaya labor"
-                    type="number"
-                    min="0"
-                  />
-                  {fieldErrors.laborFee && (
-                    <p className="text-xs text-red-500">{fieldErrors.laborFee}</p>
-                  )}
-                </CaseField>
-              {form.quoteDecision === "approve" && (
-                <CaseField
-                  label="Select APO"
-                  star={form.quoteDecision === "approve"}
-                  className="gap-0"
-                >
-                  <SearchCommandBlock 
-                    value={form.userAssign}
-                    onChange={(selectedID) =>{
-                      if(selectedID === null) {
-                        handleFieldChange("userAssign", value);
-                        return;
-                      }
-                      const selectedUser = filteredUserAssign.find(
-                        (user) => user.IDUser === selectedID
-                      );
-                      if (selectedUser) {
-                        handleFieldChange("userAssign", selectedUser.IDUser);
-                      }
-                    }}
-                    placeholder="--Select--"
-                    options={filteredUserAssign.map((user) =>({
-                      label: user.Name,
-                      value: user.IDUser,
-                    }))}
-                    renderLabel={(opt) => opt.label}
-                    getValue={(opt) => opt.value}
-                    className={'border-2 ring-1 ring-gray-200 bg-slate-100'}
-                  />
-                  {fieldErrors.userAssign && (
-                    <p className="text-xs text-red-500">{fieldErrors.userAssign}</p>
-                  )}
-                </CaseField>
+          {isPendingQuote && (
+            <CaseField label="Quote Approve Date" star>
+              <Input
+                type="date"
+                disabled={formDisabled}
+                value={form.quoteApproveDate}
+                onChange={(e) =>
+                  handleFieldChange("quoteApproveDate", e.target.value)
+                }
+              />
+              {fieldErrors.quoteApproveDate && (
+                <p className="text-xs text-red-500">{fieldErrors.quoteApproveDate}</p>
               )}
-                
-              </div>
+            </CaseField>
+          )}
 
-              <CaseField
-                label="Pilihan Tambahan"
-                span={2}
-                childClass="flex flex-col gap-3 items-start"
+          <CaseField label="Quotation Type" star>
+            <Select
+              disabled={formDisabled}
+              value={form.quotationType}
+              onValueChange={(value) => handleFieldChange("quotationType", value)}
+            >
+              <SelectTrigger className="w-full" disabled={formDisabled}>
+                <SelectValue placeholder="Pilih tipe quotation" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Simple">Simple</SelectItem>
+                <SelectItem value="Standard">Standard</SelectItem>
+              </SelectContent>
+            </Select>
+            {fieldErrors.quotationType && (
+              <p className="text-xs text-red-500">{fieldErrors.quotationType}</p>
+            )}
+          </CaseField>
+
+          <CaseField label="Labor Fee" star>
+            
+            <Input
+              disabled={formDisabled}
+              value={form.laborFee}
+              onChange={(e) => handleFieldChange("laborFee", e.target.value)}
+              placeholder="Masukkan biaya labor"
+              type="number"
+              min="0"
+            />
+            {fieldErrors.laborFee && (
+              <p className="text-xs text-red-500">{fieldErrors.laborFee}</p>
+            )}
+          </CaseField>
+
+          {form.quotationType === "Standard" && (
+            <CaseField label="VAT Value (%)" star>
+              <Input
+                disabled={formDisabled}
+                value={form.vatValue}
+                onChange={(e) => handleFieldChange("vatValue", e.target.value)}
+                placeholder="Contoh: 10"
+                type="number"
+                min="0"
+              />
+              {fieldErrors.vatValue && (
+                <p className="text-xs text-red-500">{fieldErrors.vatValue}</p>
+              )}
+            </CaseField>
+          )}
+
+          {isPendingQuote && (
+            <CaseField label="Quotation Decision" star>
+              <Select
+                disabled={formDisabled}
+                value={form.quoteDecision}
+                onValueChange={(value) => handleFieldChange("quoteDecision", value)}
               >
-                <label className="flex items-center gap-2 text-sm font-medium">
-                  <Checkbox
-                    id="useNewQuotationNo"
-                    disabled={formDisabled}
-                    value={form.quotationNote}
-                    onChange={(e) => handleFieldChange("quotationNote", e.target.value)}
-                    placeholder="Catatan tambahan untuk quotation"
-                    className="min-h-[120px]"
-                  />
-                  </label>
-                </CaseField>
-                <CaseField
-                  label="Pilihan Tambahan"
-                  span={2}
-                  childClass="flex gap-3 items-start justify-center"
-                  className={'justify-center'}
-                >
-                  <label className="flex items-center gap-2 text-sm font-medium">
-                    <Checkbox
-                    className={'border-fuchsia-400'}
-                      id="useNewQuotationNo"
-                      disabled={formDisabled}
-                      checked={form.useNewQuotationNo}
-                      onCheckedChange={(checked) =>
-                        handleCheckboxChange("useNewQuotationNo", checked)
-                      }
-                    />
-                    <span>Use new Quotation No</span>
-                  </label>
-                  <label className="flex items-center gap-2 text-sm font-medium">
-                    <Checkbox
-                    className={'border-fuchsia-400'}
-                      id="sendWa"
-                      disabled={formDisabled}
-                      checked={form.sendWa}
-                      onCheckedChange={(checked) =>
-                        handleCheckboxChange("sendWa", checked)
-                      }
-                    />
-                    <span>Send WA</span>
-                  </label>
-                  <label className="flex items-center gap-2 text-sm font-medium">
-                    <Checkbox
-                    className={'border-fuchsia-400'}
-                      id="sendEmail"
-                      disabled={formDisabled}
-                      checked={form.sendEmail}
-                      onCheckedChange={(checked) =>
-                        handleCheckboxChange("sendEmail", checked)
-                      }
-                    />
-                    <span>Send Email</span>
-                  </label>
-                </CaseField>
-              </div>
-            </CardContent>
-          </Card>
+                <SelectTrigger className="w-full" disabled={formDisabled}>
+                  <SelectValue placeholder="pilih" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="approve">Approve</SelectItem>
+                  <SelectItem value="reject">Reject</SelectItem>
+                </SelectContent>
+              </Select>
+              {fieldErrors.quoteDecision && (
+                <p className="text-xs text-red-500">{fieldErrors.quoteDecision}</p>
+              )}
+            </CaseField>
+          )}
+
+          {form.quoteDecision === "approve" && (
+            <CaseField label="Select APO" star>
+              <SearchCommandBlock
+                value={form.userAssign}
+                onChange={(selectedID) => {
+                  if (selectedID === null) {
+                    handleFieldChange("userAssign", value);
+                    return;
+                  }
+                  const selectedUser = filteredUserAssign.find(
+                    (user) => user.IDUser === selectedID
+                  );
+                  if (selectedUser) {
+                    handleFieldChange("userAssign", selectedUser.IDUser);
+                  }
+                }}
+                placeholder="--Select--"
+                options={filteredUserAssign.map((user) => ({
+                  label: user.Name,
+                  value: user.IDUser,
+                }))}
+                renderLabel={(opt) => opt.label}
+                getValue={(opt) => opt.value}
+                className={"border-2 ring-1 ring-gray-200 bg-slate-100"}
+              />
+              {fieldErrors.userAssign && (
+                <p className="text-xs text-red-500">{fieldErrors.userAssign}</p>
+              )}
+            </CaseField>
+          )}
+        </div>
+
+        {/* RIGHT SIDE */}
+        <div className="flex flex-col gap-4">
+          <CaseField
+            label="Catatan Tambahan"
+            span={2}
+            childClass="flex flex-col gap-3 items-start"
+          >
+            <Textarea
+              disabled={formDisabled}
+              value={form.quotationNote}
+              onChange={(e) =>
+                handleFieldChange("quotationNote", e.target.value)
+              }
+              placeholder="Catatan tambahan untuk quotation"
+              className="min-h-[120px] w-full"
+            />
+          </CaseField>
+
+          <CaseField
+            label="Pilihan Tambahan"
+            span={2}
+            childClass="flex gap-3 items-start justify-start"
+          >
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <Checkbox
+                className={"border-fuchsia-400"}
+                id="useNewQuotationNo"
+                disabled={formDisabled}
+                checked={form.useNewQuotationNo}
+                onCheckedChange={(checked) =>
+                  handleCheckboxChange("useNewQuotationNo", checked)
+                }
+              />
+              <span>Use new Quotation No</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <Checkbox
+                className={"border-fuchsia-400"}
+                id="sendWa"
+                disabled={formDisabled}
+                checked={form.sendWa}
+                onCheckedChange={(checked) =>
+                  handleCheckboxChange("sendWa", checked)
+                }
+              />
+              <span>Send WA</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <Checkbox
+                className={"border-fuchsia-400"}
+                id="sendEmail"
+                disabled={formDisabled}
+                checked={form.sendEmail}
+                onCheckedChange={(checked) =>
+                  handleCheckboxChange("sendEmail", checked)
+                }
+              />
+              <span>Send Email</span>
+            </label>
+          </CaseField>
+        </div>
+      </CardContent>
+    </Card>
 
           <Card>
             <CardHeader>

--- a/test-vite/src/components/model/QuotationModal.jsx
+++ b/test-vite/src/components/model/QuotationModal.jsx
@@ -165,15 +165,16 @@ const QuotationDialog = ({
   const [lineErrors, setLineErrors] = useState({});
 
   const [roleAssign, setRoleAssign] = useState([]);
+  const [isDirty, setIsDirty] = useState(false);
 
-  const fetchUserAssign = async (role) => {
+  const fetchUserAssign = useCallback(async (role) => {
     try {
       const res = await ApiCustomer.get(`/api/user?role=${role}`);
       setRoleAssign(res.data.data);
     } catch (err) {
       console.error("Error fetching role: ", err);
     }
-  };
+  }, []);
 
   const defaultFormState = useMemo(() => {
     const quotationDate =
@@ -216,12 +217,25 @@ const QuotationDialog = ({
 
   const [form, setForm] = useState(defaultFormState);
 
-  useEffect(() => {
+  const resetForm = useCallback(() => {
     setForm(defaultFormState);
     setFieldErrors({});
     setLineErrors({});
-    fetchUserAssign('apo');
+    setIsDirty(false);
   }, [defaultFormState]);
+
+  useEffect(() => {
+    fetchUserAssign("apo");
+  }, [fetchUserAssign]);
+
+  useEffect(() => {
+    if (isDirty) return;
+    resetForm();
+  }, [defaultFormState, isDirty, resetForm]);
+
+  useEffect(() => {
+    setIsDirty(false);
+  }, [caseId, status]);
 
   const filteredUserAssign = roleAssign.filter(
     (user) => user.Role === "apo"
@@ -275,7 +289,11 @@ const QuotationDialog = ({
   }, [form.quoteDecision])
 
   const handleFieldChange = (field, value) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
+    setForm((prev) => {
+      if (prev[field] === value) return prev;
+      setIsDirty(true);
+      return { ...prev, [field]: value };
+    });
     setFieldErrors((prev) => {
       if (!prev[field]) return prev;
       const next = { ...prev };
@@ -289,12 +307,19 @@ const QuotationDialog = ({
   };
 
   const handleLineItemChange = (internalId, field, value) => {
-    setForm((prev) => ({
-      ...prev,
-      lineItems: prev.lineItems.map((item) =>
-        item.internalId === internalId ? { ...item, [field]: value } : item
-      ),
-    }));
+    setForm((prev) => {
+      let hasChanged = false;
+      const nextLineItems = prev.lineItems.map((item) => {
+        if (item.internalId !== internalId) return item;
+        if (item[field] === value) return item;
+        hasChanged = true;
+        return { ...item, [field]: value };
+      });
+
+      if (!hasChanged) return prev;
+      setIsDirty(true);
+      return { ...prev, lineItems: nextLineItems };
+    });
 
     setLineErrors((prev) => {
       const existing = prev[internalId];
@@ -358,7 +383,7 @@ const QuotationDialog = ({
     );
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (formDisabled) return;
     if (!validateForm()) return;
 
@@ -397,7 +422,12 @@ const QuotationDialog = ({
     // return console.log("ON PAYLOAD KONT", payload)
     
     // if(quoteDecisionValue === 'Rejected') pa
-    onSubmit?.(payload);
+    try {
+      await Promise.resolve(onSubmit?.(payload));
+      resetForm();
+    } catch (error) {
+      console.error("Failed to submit quotation:", error);
+    }
   };
 
   return (

--- a/test-vite/src/components/model/RepairActionModal.jsx
+++ b/test-vite/src/components/model/RepairActionModal.jsx
@@ -17,7 +17,7 @@ import { debounce } from "lodash";
 import { SearchCommandBlock } from "../sc-select";
 import ApiCustomer from "@/api";
 import { toast } from "sonner";
-export const RepairActionDialog = ({ open, onOpenChange, onSubmit, canEdit, workOrders }) => {
+export const RepairActionDialog = ({ open, onOpenChange, onSubmit, canEdit, onCancelWo, workOrders }) => {
   const [step, setStep] = useState("form");
   const [NMUList, setNMUList] = useState([]);
   const [NMUItemNeed, setNMUItemNeed] = useState(false);
@@ -39,6 +39,7 @@ export const RepairActionDialog = ({ open, onOpenChange, onSubmit, canEdit, work
     ceAnalysis: "",
     repairAction: "",
     delayCode : null,
+    cancelReason: "",
   });
 
   const fetchServiceType = async (problemCategory) => {
@@ -212,6 +213,14 @@ console.log(formData);
         {step === "form" && (
           <Card className="mt-2">
             <CardContent className="grid grid-cols-4 gap-3">
+              {onCancelWo !== false && (
+                <CaseField label="Cancel Reason" lock={!canEdit} span={3} star={onCancelWo}>
+                  <Textarea
+                    onChange={(e) => handleChange("cancelReason", e.target.value)}
+                  />
+                </CaseField>
+              )}
+
               <CaseField label="Problem category" lock={!canEdit}>
                 <SearchCommandBlock
                   value={problemCategory}

--- a/test-vite/src/components/model/RepairActionModal.jsx
+++ b/test-vite/src/components/model/RepairActionModal.jsx
@@ -343,7 +343,7 @@ console.log(formData);
         {step === "confirm" && (
           <div className="mt-4 space-y-4">
             <p className="text-sm text-muted-foreground">
-                <span className="text-red-600 font-semibold">⚠️ WARNING : Status Work Order akan berubah menjadi CLOSED_POSTED</span>
+                <span className="text-red-600 font-semibold">⚠️ WARNING : Status Work Order akan berubah menjadi {onCancelWo ? "CLOSED_CANCEL" : "CLOSED_POSTED"}</span>
               <br />Berikut adalah data yang akan dikirim:
             </p>
 

--- a/test-vite/src/components/model/sc-modal.jsx
+++ b/test-vite/src/components/model/sc-modal.jsx
@@ -5261,6 +5261,20 @@ console.log("Asset Info OTC : ",isOutWarranty)
       );
     });
     const totalPages = Math.ceil(filteredPartCatalog.length / PAGE_SIZE);
+    const MAX_PAGES_SHOWN = 3;
+  const getPaginationPages = () => {
+    if (totalPages <= MAX_PAGES_SHOWN) {
+      return Array.from({ length: totalPages }, (_, i) => i + 1);
+    }
+    if (currentPage <= 2) {
+      return [1, 2, 3];
+    }
+    if (currentPage >= totalPages - 1) {
+      return [totalPages - 2, totalPages - 1, totalPages];
+    }
+    return [currentPage - 1, currentPage, currentPage + 1];
+  };
+  const paginationPages = getPaginationPages();
     const currentPageData = useMemo(() => {
       const start = (currentPage - 1) * PAGE_SIZE;
       return filteredPartCatalog.slice(start, start + PAGE_SIZE);
@@ -5572,17 +5586,17 @@ console.log("Asset Info OTC : ",isOutWarranty)
                               />
                             </PaginationItem>
 
-                            {Array.from({ length: totalPages }, (_, i) => (
-                              <PaginationItem key={i}>
+                            {paginationPages.map((pages) => (
+                              <PaginationItem key={pages}>
                                 <PaginationLink
                                   href="#"
-                                  isActive={currentPage === i + 1}
+                                  isActive={currentPage === pages}
                                   onClick={(e) => {
                                     e.preventDefault();
-                                    handlePageChange(i + 1);
+                                    handlePageChange(pages);
                                   }}
                                 >
-                                  {i + 1}
+                                  {pages}
                                 </PaginationLink>
                               </PaginationItem>
                             ))}

--- a/test-vite/src/layout/Cm_Page.jsx
+++ b/test-vite/src/layout/Cm_Page.jsx
@@ -63,7 +63,7 @@ export default function CashManagement() {
 
                 return dateB - dateA; // newest first
             });
-            const recentCases = sortedCases.slice(0, 3);
+            const recentCases = sortedCases.slice(0, 5);
             setCaseData(recentCases);
             return resCaseData.data.data;
         } catch (err) {
@@ -136,10 +136,11 @@ export default function CashManagement() {
         }
         try {
             setQuotationSubmitting(true);
-            // return console.log("Submit : ",payload)
+            const targetAssignUser = payload.quoteDecision === "Rejected" ? selectedCase.caseinformation.workorder[0].OwnerID : user.id !== payload?.userAssign ? payload.userAssign : user.id
+            // return console.log("Submit : ",targetAssignUser)
             const apiPayload = {
                 ...payload,
-                userAssign: user.id !== payload?.userAssign ? payload.userAssign : user.id,
+                userAssign: targetAssignUser,
             };
             console.log("Sending payload:", apiPayload);
             const endpoint = payload.quotationNo

--- a/test-vite/src/lib/utils.js
+++ b/test-vite/src/lib/utils.js
@@ -22,4 +22,12 @@ export function formatDate(dateString) {
   });
 }
 
+export function formatAccountingRupiah(value) {
+  if (value == null || value === "") return "---";
+  return new Intl.NumberFormat("id-ID", {
+    style: "currency",
+    currency: "IDR",
+    minimumFractionDigits: 0,
+  }).format(value);
+}
 

--- a/test-vite/src/pages/CaseDetail.jsx
+++ b/test-vite/src/pages/CaseDetail.jsx
@@ -97,6 +97,7 @@ import { toast } from "sonner";
 import { cn, formatAccountingRupiah } from "@/lib/utils";
 import { map, set } from "lodash";
 import QuotationDialog from "@/components/model/QuotationModal";
+import InvoiceDialog from "@/components/model/InvoiceModal"
 /**
  * TODO : 
  * ADDING THIS FUNCTION GLOBALLY OR MAKE THE CASE DETAIL INTO ONE
@@ -147,6 +148,7 @@ export const STATUS_ENUM_TO_LABEL = {
   PartAvailable: "Part Available",
   RepairProgress: "Repair Progress",
   FinishRepair: "Finish Repair",
+  CancelRepair: "Cancel Repair",
 };
 
 export const STATUS_LABELS = Object.keys(STATUS_ENUM_TO_LABEL);

--- a/test-vite/src/pages/CaseDetail.jsx
+++ b/test-vite/src/pages/CaseDetail.jsx
@@ -94,7 +94,7 @@ import { parseNoteText } from "@/lib/utils.jsx";
 import SignatureWrite from "@/components/SignaturePad";
 import { description } from "@/components/sc-chart";
 import { toast } from "sonner";
-import { cn, formatAccountingRupiah } from "@/lib/utils";
+import { cn, formatAccountingRupiah, formatDate } from "@/lib/utils";
 import { map, set } from "lodash";
 import QuotationDialog from "@/components/model/QuotationModal";
 import InvoiceDialog from "@/components/model/InvoiceModal"
@@ -299,6 +299,18 @@ export const TabsServiceCaseDetails = ({
   });
 
   const [signature, setSignature] = useState(null);
+
+  // Modal Quotation
+  const [openDialogQuotation, setOpenDialogQuotation] = useState(false);
+  const [quotationInitialData, setQuotationInitialData] = useState(null);
+  const [quotationMaterialItems, setQuotationMaterialItems] = useState([]);
+  const [quotationLoading, setQuotationLoading] = useState(false);
+  const [quotationSubmitting, setQuotationSubmitting] = useState(false);
+
+  const [invoiceDialogOpen, setInvoiceDialogOpen] = useState(false);
+  const [invoiceData, setInvoiceData] = useState(null);
+  const [invoiceLoading, setInvoiceLoading] = useState(false);
+  const [invoiceSubmitting, setInvoiceSubmitting] = useState(false);
 
   const handleCaseDetails = (field) => (value) => {
     setCaseDetails((prev) => ({ ...prev, [field]: value }));
@@ -870,6 +882,110 @@ const openPopup = () => {
     setOpenWorkOrder(true);
     setServiceCatalogType(type)
   };
+
+  const fetchInvoiceData = useCallback(async () => {
+    if (!caseDetails?.CaseID) return null;
+    setInvoiceLoading(true);
+    try {
+      const response = await ApiCustomer.get(
+        `/api/invoice-information?caseId=${caseDetails.CaseID}`
+      );
+      const payload = response.data?.data ?? null;
+      setInvoiceData(payload);
+      return payload;
+    } catch (error) {
+      console.error("Failed to fetch invoice:", error);
+      toast.error(
+        error.response?.data?.message ?? "Gagal mengambil data invoice."
+      );
+      return null;
+    } finally {
+      setInvoiceLoading(false);
+    }
+  }, [caseDetails?.CaseID]);
+
+  useEffect(() => {
+    if (!caseDetails?.CaseID) return;
+    fetchInvoiceData();
+  }, [caseDetails?.CaseID, fetchInvoiceData]);
+
+  const handleInvoiceOpenChange = (nextOpen = true) => {
+    setInvoiceDialogOpen(nextOpen);
+    if (nextOpen) {
+      fetchInvoiceData();
+    } else {
+      setInvoiceSubmitting(false);
+    }
+  };
+
+  const handleInvoiceSubmit = async (payload) => {
+    if (!caseDetails?.CaseID) return;
+    if (!user?.id) {
+      toast.error("User tidak valid. Silakan login kembali.");
+      return;
+    }
+    try {
+      setInvoiceSubmitting(true);
+      const hasInvoice = Boolean(payload.invoiceNo);
+      const endpoint = hasInvoice
+        ? `/api/invoice-information/${payload.invoiceNo}`
+        : "/api/invoice-information";
+      const method = hasInvoice ? "patch" : "post";
+      const requester =
+        method === "patch"
+          ? ApiCustomer.patch.bind(ApiCustomer)
+          : ApiCustomer.post.bind(ApiCustomer);
+
+      const requestBody = {
+        ...payload,
+      };
+
+      if (!hasInvoice) {
+        requestBody.createdBy = user.id;
+      }
+
+      const response = await requester(endpoint, requestBody);
+      setInvoiceData(response.data?.data ?? null);
+      toast.success(
+        hasInvoice
+          ? "Invoice berhasil diperbarui."
+          : "Invoice berhasil dibuat."
+      );
+      setInvoiceDialogOpen(false);
+      await fetchInvoiceData();
+    } catch (error) {
+      console.error("Failed to save invoice:", error);
+      const message =
+        error.response?.data?.message ?? "Gagal menyimpan invoice.";
+      toast.error(message);
+    } finally {
+      setInvoiceSubmitting(false);
+    }
+  };
+
+  const ensureInvoiceBeforeClose = async () => {
+    const data = await fetchInvoiceData();
+    if (!data) {
+      await Swal.fire({
+        icon: "warning",
+        title: "Quotation belum tersedia",
+        text: "Buat quotation beserta invoice sebelum menutup case.",
+      });
+      return false;
+    }
+    if (!data.invoice) {
+      await Swal.fire({
+        icon: "warning",
+        title: "Invoice belum tersedia",
+        text: "Input invoice terlebih dahulu sebelum menutup case.",
+        confirmButtonText: "Input Invoice",
+      });
+      handleInvoiceOpenChange(true);
+      return false;
+    }
+    return true;
+  };
+
   const saveAndCloseCase = async () => {
     // Role guard: only FD can close a Case
     const tokenUser = getUserFromToken();
@@ -889,6 +1005,11 @@ const openPopup = () => {
   //   });
   //   return;
   // }
+
+    const invoiceReady = await ensureInvoiceBeforeClose();
+    if (!invoiceReady) {
+      return;
+    }
 
     const confirmResult = await Swal.fire({
       title: "Confirm Save",
@@ -997,12 +1118,7 @@ const openPopup = () => {
     }
   };
 
-  // Modal Quotation
-  const [openDialogQuotation, setOpenDialogQuotation] = useState(false);
-  const [quotationInitialData, setQuotationInitialData] = useState(null);
-  const [quotationMaterialItems, setQuotationMaterialItems] = useState([]);
-  const [quotationLoading, setQuotationLoading] = useState(false);
-  const [quotationSubmitting, setQuotationSubmitting] = useState(false);
+
 
 
   const fieldMO = (caseDetails) => {
@@ -1163,6 +1279,18 @@ const openPopup = () => {
         };
     };
 
+  const invoiceSummary = invoiceData?.invoice;
+  const invoiceQuotation = invoiceData?.quotation;
+  const invoiceNotificationLabel =
+    [
+      invoiceSummary?.sendInvoice && "Invoice",
+      invoiceSummary?.sendWa && "WA",
+      invoiceSummary?.sendEmail && "Email",
+      invoiceSummary?.sendErf && "ERF",
+    ]
+      .filter(Boolean)
+      .join(", ") || "-";
+
   return (
     <>
       <div className="flex items-center border-1 sticky top-15 z-5 bg-gray-50 overflow-auto">
@@ -1227,6 +1355,17 @@ const openPopup = () => {
         />
       </div>
       <div>
+        <InvoiceDialog
+          open={invoiceDialogOpen}
+          onOpenChange={handleInvoiceOpenChange}
+          quotation={invoiceData?.quotation}
+          invoice={invoiceData?.invoice}
+          loading={invoiceLoading}
+          submitting={invoiceSubmitting}
+          onSubmit={handleInvoiceSubmit}
+        />
+      </div>
+      <div>
           <ServiceCase
             caseDetails={caseDetails}
             formData={caseNoteFormData}
@@ -1254,6 +1393,10 @@ const openPopup = () => {
             productForm={productForm}
             setProductForm={setProductForm}
             handleProductChange={handleProductChange}
+            invoiceLoading={invoiceLoading}
+            invoiceSummary={invoiceSummary}
+            invoiceQuotation={invoiceQuotation}
+            invoiceNotificationLabel={invoiceNotificationLabel}
           />
       </div>
     </>
@@ -1286,7 +1429,11 @@ export const ServiceCase = ({
   refreshFetchPage,
   productForm,
   setProductForm,
-  handleProductChange
+  handleProductChange,
+  invoiceLoading,
+  invoiceSummary,
+  invoiceQuotation,
+  invoiceNotificationLabel,
 }) => {
   const { open } = useSidebar();
 
@@ -3349,11 +3496,101 @@ if (caseDetails.CaseStatus !== "Close") {
               </Card>
              
               <Card className={"flex-col col-span-2"}>
-                <CardHeader>
-                  <CardTitle className={"text-lg"}>Invoice Information</CardTitle>
+                <CardHeader className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className={"text-lg"}>Invoice Information</CardTitle>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleInvoiceOpenChange(true)}
+                      disabled={invoiceLoading || caseDetails?.CaseStatus === "Close"}
+                    >
+                      {invoiceSummary ? "Edit Invoice" : "Buat Invoice"}
+                    </Button>
+                  </div>
                   <hr />
                 </CardHeader>
                 <CardContent>
+                  {invoiceLoading ? (
+                    <p className="text-sm text-muted-foreground">
+                      Memuat data invoice...
+                    </p>
+                  ) : invoiceSummary ? (
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                      <CaseField label={"Quotation No"} lock>
+                        <Input value={invoiceQuotation?.quotationNo || "-"} readOnly />
+                      </CaseField>
+                      <CaseField label={"Invoice No"} lock>
+                        <Input value={invoiceSummary.invoiceNo} readOnly />
+                      </CaseField>
+                      <CaseField label={"Subtotal"} lock>
+                        <Input
+                          value={formatAccountingRupiah(invoiceQuotation?.subtotal)}
+                          readOnly
+                        />
+                      </CaseField>
+                      <CaseField label={"Grand Total"} lock>
+                        <Input
+                          value={formatAccountingRupiah(invoiceQuotation?.grandTotal)}
+                          readOnly
+                        />
+                      </CaseField>
+                      <CaseField label={"Amount Receive"} lock>
+                        <Input
+                          value={formatAccountingRupiah(invoiceSummary.amountReceive)}
+                          readOnly
+                        />
+                      </CaseField>
+                      <CaseField label={"Amount Difference"} lock>
+                        <Input
+                          value={formatAccountingRupiah(invoiceSummary.amountDiff)}
+                          readOnly
+                        />
+                      </CaseField>
+                      <CaseField
+                        label={"Alasan Selisih"}
+                        lock
+                        hide={!invoiceSummary.amountDiffReason}
+                      >
+                        <Input
+                          value={invoiceSummary.amountDiffReason || "-"}
+                          readOnly
+                        />
+                      </CaseField>
+                      <CaseField label={"Payment Type"} lock>
+                        <Input value={invoiceSummary.paymentType || "-"} readOnly />
+                      </CaseField>
+                      <CaseField label={"Tanggal Terima"} lock>
+                        <Input
+                          value={formatDate(invoiceSummary.amountReceiveDate)}
+                          readOnly
+                        />
+                      </CaseField>
+                      <CaseField label={"Notifikasi"} lock>
+                        <Input value={invoiceNotificationLabel} readOnly />
+                      </CaseField>
+                      <CaseField label={"Catatan"} lock span={2}>
+                        <Textarea
+                          value={invoiceSummary.amountReceiveNote || "-"}
+                          rows={3}
+                          readOnly
+                        />
+                      </CaseField>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+                      <p>Belum ada invoice untuk case ini.</p>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        className="w-fit"
+                        onClick={() => handleInvoiceOpenChange(true)}
+                        disabled={caseDetails?.CaseStatus === "Close"}
+                      >
+                        Buat Invoice
+                      </Button>
+                    </div>
+                  )}
                 </CardContent>
               </Card>
             </div>

--- a/test-vite/src/pages/CaseDetail.jsx
+++ b/test-vite/src/pages/CaseDetail.jsx
@@ -786,6 +786,7 @@ const openPopup = () => {
 
   // Deprecated: previously used for single textarea notes display
   // Replaced by notesList table
+  const [cancelState, setCancelState] = useState(false);
 
   const buttons = [
     {
@@ -808,7 +809,13 @@ const openPopup = () => {
     {
       icon: CopyX,
       label: "Close Case",
-      onClick: () => saveAndCloseCase(),
+      onClick: () => saveAndCloseCase(false),
+      roles: ["admin", "fd"],
+    },
+    {
+      icon: CopyX,
+      label: "Cancel Case",
+      onClick: () => saveAndCloseCase(true),
       roles: ["admin", "fd"],
     },
     { icon: RotateCw, label: "Refresh", 
@@ -938,6 +945,7 @@ const openPopup = () => {
 
       const requestBody = {
         ...payload,
+        caseId : caseDetails?.CaseID
       };
 
       if (!hasInvoice) {
@@ -953,6 +961,10 @@ const openPopup = () => {
       );
       setInvoiceDialogOpen(false);
       await fetchInvoiceData();
+      //do what after submit??
+      // IDK, just add the save and close again, maybe
+      // --miku21
+      saveAndCloseCase(cancelState);
     } catch (error) {
       console.error("Failed to save invoice:", error);
       const message =
@@ -974,6 +986,10 @@ const openPopup = () => {
       return false;
     }
     if (!data.invoice) {
+      /**
+       * TODO FOR SLAMET : 
+       * MAKE TIS CONFIRMATION INTO SOMETHING ELSE
+       */
       await Swal.fire({
         icon: "warning",
         title: "Invoice belum tersedia",
@@ -986,7 +1002,9 @@ const openPopup = () => {
     return true;
   };
 
-  const saveAndCloseCase = async () => {
+
+  const saveAndCloseCase = async (cancell = false) => {
+    setCancelState(cancell); //default initialization
     // Role guard: only FD can close a Case
     const tokenUser = getUserFromToken();
     if (!tokenUser || String(tokenUser.role).toLowerCase() !== 'fd') {
@@ -1005,15 +1023,22 @@ const openPopup = () => {
   //   });
   //   return;
   // }
+  // return console.log(caseDetails?.asset_information?.WarrantyOTCCode?.WarrantyCondition);
+  if(caseDetails?.asset_information?.WarrantyOTCCode?.WarrantyCondition === "OutWarranty"){
 
     const invoiceReady = await ensureInvoiceBeforeClose();
     if (!invoiceReady) {
       return;
     }
+  }
 
+
+
+  const targetStatus = cancell ? "CANCEL" : "CLOSED"
+  const targetSystemCaseStatus = cancell ? "Cancel" : "Close"
     const confirmResult = await Swal.fire({
       title: "Confirm Save",
-      text: "This will give the Case status as CLOSED. Are you sure you want to save changes?",
+      text: "This will give the Case status as "+targetStatus+". Are you sure you want to save changes?",
       icon: "warning",
       showCancelButton: true,
       confirmButtonColor: "#3085d6",
@@ -1038,7 +1063,7 @@ const openPopup = () => {
       try {
         const woRes = await ApiCustomer.get(`/api/work-order?CaseID=${caseDetails.CaseID}`);
         const workOrders = Array.isArray(woRes.data?.data) ? woRes.data.data : [];
-        const openWOs = workOrders.filter(wo => String(wo.SystemStatus).toUpperCase() !== 'CLOSED_POSTED');
+        const openWOs = workOrders.filter(wo => String(wo.SystemStatus).toUpperCase() !== 'CLOSED_POSTED' && String(wo.SystemStatus).toUpperCase() !== 'CLOSED_CANCELLED');
         if (openWOs.length > 0) {
           Swal.close();
           return Swal.fire({
@@ -1051,7 +1076,7 @@ const openPopup = () => {
         for (const wo of workOrders) {
           const moRes = await ApiCustomer.get(`/api/material-order?WOID=${wo.WOID}`);
           const mos = Array.isArray(moRes.data?.data) ? moRes.data.data : [];
-          const mosNotClosed = mos.filter(mo => String(mo.OrderStatus).toLowerCase() !== 'closed');
+          const mosNotClosed = mos.filter(mo => String(mo.OrderStatus).toLowerCase() !== 'closed' && String(mo.OrderStatus).toLowerCase() !== 'cancelled');
           if (mosNotClosed.length > 0) {
             Swal.close();
             return Swal.fire({
@@ -1074,7 +1099,7 @@ const openPopup = () => {
       const res = await ApiCustomer.patch(
         `/api/case-information/${caseDetails.CaseID}`,
         {
-          CaseStatus: "Close",
+          CaseStatus: targetSystemCaseStatus,
           CaseClosedDate: new Date().toISOString(), 
         }
       );

--- a/test-vite/src/pages/CaseDetail.jsx
+++ b/test-vite/src/pages/CaseDetail.jsx
@@ -94,7 +94,7 @@ import { parseNoteText } from "@/lib/utils.jsx";
 import SignatureWrite from "@/components/SignaturePad";
 import { description } from "@/components/sc-chart";
 import { toast } from "sonner";
-import { cn } from "@/lib/utils";
+import { cn, formatAccountingRupiah } from "@/lib/utils";
 import { map, set } from "lodash";
 import QuotationDialog from "@/components/model/QuotationModal";
 /**
@@ -801,7 +801,7 @@ const openPopup = () => {
       onClick: () => window.location.reload(),
       roles: ["admin", "fd","user", "apo", "ce", "lg", "celead", "spv", "ps","cm"],
     },
-    { icon: MessageSquareText, label: "Quotation",onClick: () => handleQuotationOpenChange(),  roles: ["admin","cm"]},
+    { icon: MessageSquareText, label: "Quotation",onClick: () => handleQuotationOpenChange(true),  roles: ["admin","cm"]},
     { icon: StepBack, label: "SRF", 
       onClick: async () => {
         // return console.log(user);
@@ -1103,6 +1103,10 @@ const openPopup = () => {
                     ...payload,
                     userAssign: user.id !== payload?.userAssign ? payload.userAssign : user.id,
                 };
+                if(apiPayload.quoteDecision === "Rejected"){
+                  apiPayload.userAssign = caseDetails.workorder[0]?.OwnerID;
+                }
+                
                 console.log("Sending payload:", apiPayload);
                 const endpoint = payload.quotationNo
                     ? `/api/quotation-information/${payload.quotationNo}`
@@ -3262,29 +3266,33 @@ if (caseDetails.CaseStatus !== "Close") {
                  </CaseField>
                   <CaseField label={"Quotation amount"} lock> 
                   <Input 
-                    value={caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.Subtotal || "---"}
+                    value={formatAccountingRupiah(caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.Subtotal)}
                   />
                  </CaseField>
                  <CaseField label={"VAT value (%)"} lock> 
                   <Input 
-                    value={caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.VatValue || "---"}
+                    value={caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.VatValue 
+                      ? caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.VatValue + "%" 
+                      : "---"}
                   />
                  </CaseField>
                    <CaseField label={"Quotation amount + VAT"} lock> 
                   <Input 
-                    value={caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.GrandTotal || "---"}
+                    value={formatAccountingRupiah(caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.GrandTotal)}
                   />
                  </CaseField>
-                 <CaseField label={"Quotation request date"} lock> 
+                 <CaseField label={"Quotation Request date"} lock> 
                   <DatePicker 
                     value={new Date(caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.QuotationDate)}
                   />
                  </CaseField>
-                  <CaseField label={"Quotation date"} lock> 
-                  <DatePicker 
-                    value={new Date(caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.QuotationApprovedDate)}
-                  />
-                 </CaseField>
+                 {caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.QuotationApprovedDate !== null && (
+                  <CaseField label={"Quotation Response date"} lock> 
+                    <DatePicker 
+                      value={new Date(caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.QuotationApprovedDate)}
+                    />
+                  </CaseField>
+                 )}
                   <CaseField label={"Quote decision"} lock> 
                   <Input 
                     value={caseDetails.workorder[0]?.materialorder[0]?.materialorderlineitems[0]?.quotation_lineitem[0]?.quotation?.QuoteDecision || "---"}

--- a/test-vite/src/pages/services/service-case.jsx
+++ b/test-vite/src/pages/services/service-case.jsx
@@ -748,7 +748,7 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
     try {
       const moRes = await ApiCustomer.get(`/api/material-order?WOID=${workOrders.WOID}`);
       const mos = Array.isArray(moRes.data?.data) ? moRes.data.data : [];
-      const mosNotClosed = mos.filter(mo => String(mo.OrderStatus).toLowerCase() !== 'closed');
+      const mosNotClosed = mos.filter(mo => String(mo.OrderStatus).toLowerCase() !== 'closed' && String(mo.OrderStatus).toLowerCase() !== 'cancelled');
       if (mosNotClosed.length > 0) {
         Swal.close();
         Swal.fire({

--- a/test-vite/src/pages/services/service-case.jsx
+++ b/test-vite/src/pages/services/service-case.jsx
@@ -622,6 +622,7 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
 
   //modal handle repair action
   const [openRepairDialog, setOpenRepairDialog] = useState(false);
+  const [onCancelWo, setOnCancelWo] = useState(false)
 
   const handleSave = async () => {
     try {
@@ -712,6 +713,18 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
       onClick:async () => {
         const isValid = await validate();
         if (isValid !== false) {
+          setOnCancelWo(false);
+          setOpenRepairDialog(true);
+        }
+      },
+    },
+    {
+      icon: CopyX,
+      label: "Cancel WOKONTOL",
+      onClick:async () => {
+        const isValid = await validate();
+        if (isValid !== false) {
+          setOnCancelWo(true);
           setOpenRepairDialog(true);
         }
       },
@@ -804,6 +817,7 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
 
   }
   const saveAndCloseWorkOrder = async (repairFormData) => {
+    // return console.log(repairFormData);
     try {
       Swal.fire({
         title: "Saving...",
@@ -826,6 +840,7 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
 
       // return console.log("Repair PROM KOOJRN ",repairFormData);
 
+      const statusTarget = onCancelWo ? "CLOSED_CANCELLED" : "CLOSED_POSTED";
       const res = await ApiCustomer.patch(
         `/api/work-order/${workOrders.WOID}`,
         {
@@ -837,7 +852,9 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
           DefectDesc: repairFormData.defectDesc,
           RepairAction: repairFormData.repairAction,
           ServiceTypeId: repairFormData.serviceType,
-          SystemStatus: "CLOSED_POSTED",
+          CancelReason: repairFormData.cancelReason,
+          SystemStatus: statusTarget,
+          IsCancel: onCancelWo
         }
       );
       if (res.data.success) {
@@ -856,19 +873,20 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
         })
         // console.log("wololo",workOrders)
         //update log customer
+        const statusCaseTarget = onCancelWo ? "CancelRepair" : "FinishRepair";
         const caseLog = await ApiCustomer.post("/api/actionlog",{
           CaseId: `${workOrders.CaseID}`,
           ReferenceId: `${workOrders.CaseID}`,
           model: "Case",
           dataOld: workOrders?.caseinformation?.CaseStatus,
-          dataNew: "Finish Repair",
+          dataNew: statusCaseTarget,
           changedBy: token.user.id,
-          logDescription: `Edit : Changed Case Status ${workOrders.CaseID} from ${workOrders?.caseinformation?.CaseStatus} to Finish Repair`
+          logDescription: `Edit : Changed Case Status ${workOrders.CaseID} from ${workOrders?.caseinformation?.CaseStatus} to ${statusCaseTarget}`
         })
         //update Case status
         const caseChangeStatus = await ApiCustomer.patch(`/api/case-information/${workOrders.CaseID}`,{
           Owner: workOrders?.caseinformation?.CreatedBy,
-          CaseStatus: "FinishRepair"
+          CaseStatus: statusCaseTarget
         })
 
         const previousOwnerId = workOrders?.caseinformation?.Owner;
@@ -966,6 +984,7 @@ export const TabsServiceWO = ({ workOrders, SLA, setSLA, WOGeneral }) => {
         onOpenChange={setOpenRepairDialog}
         onSubmit={handleRepairSubmit}
         canEdit={true}
+        onCancelWo={onCancelWo}
         
         //data
         workOrders={workOrders}


### PR DESCRIPTION
# 🇯🇵✨ Pull Request — Invoice System, Quotation Flow Upgrade, and Case/WO Enhancements

> *“A well-crafted system is like a quiet morning in Kyoto — balanced, intentional, and free from clutter.”*

This PR brings significant improvements to the workflow of **invoice processing**, **quotation logic**, **case handling**, and **work-order lifecycle**, along with UI refinements to provide a smoother and more predictable experience.

---

## 🌸 Summary

This update introduces:

* A complete **invoice management system** (DB, API, and frontend integration)
* Improved **quotation decision flow** (approval/rejection, owner assignment, and cancellation)
* **Work Order cancellation flow** with reason tracking
* Extended status mapping for cases
* Refactored UI components for clarity and a more polished user experience
  (QuotationModal, CaseDetail, RepairActionModal, and sc-modal pagination)

---

## 🏯 Database & Prisma Updates

### 📌 Migrations

1. **Work Order cancellation fields + New Invoice Table**

   * `workorder`

     * `IsCancel BOOLEAN DEFAULT false`
     * `CancelReason TEXT`
   * New table `invoicetable` containing:

     * `InvoiceNo`, `QuotationNo` (FK)
     * `AmountReceive`, `AmountDiff` (now DECIMAL(12,2))
     * Payment info, send flags, notes, timestamps
     * `CreatedBy` (FK to `User.IDUser`)

2. **Extended `CaseStatus` enum**

   * Added: `CancelRepair`

3. **Decimal limits added**

   * `AmountReceive` and `AmountDiff` now `DECIMAL(12,2)`

> ⚠️ Requires backfilling `CreatedBy` on existing invoices.

---

## 🖥️ Backend API Enhancements

### 🗂️ Case Information

* Expanded GET with richer relational data for:

  * Material orders + line items
  * Quotation associations
  * Case owner info

### 🧾 Quotation PATCH Logic

Improvements include:

* Correct cancellation behavior for rejected or partially rejected line items
* Proper owner assignment logic
* Case status mapping:

  * Approved → `Quote_Approved`
  * Rejected → `Quote_Rejected`
  * Pending or fallback
* Writes quotation notes to `casenotes`
* Prepares structured action logs (owner/status)

### 🔧 Service Log — Create Order

* Refined warranty/OW messaging
* Status now correctly assigned:

  * Out warranty → `Quote_Requested`
  * Normal → `PartRequest`
* Cleaned ownership routing
* Improved logging structure

### 📝 Work Order PATCH

Supports:

* Closing normally
* Cancelling with reason
* Updated `SystemStatus` based on flow
* Syncs case status → `FinishRepair` or `CancelRepair`

### 💴 Invoice API (New)

* Endpoints for creating, reading, updating invoices
* Validates decimals, enforces `CreatedBy`
* Integrated Prisma transactions
* Ensures a case **cannot be closed without an invoice**

---

## 🎎 Frontend Enhancements

### 💰 Cash Management Page

* Shows 5 latest cases
* Improved owner assignment for rejected quotations

### 🧾 QuotationModal

Refactored with:

* Two-column layout
* Conditional VAT/APO fields
* Cleaned field resets
* More reliable dirty-state tracking
* Better `partApproved` defaults (true unless rejected)

### 📘 CaseDetail

* Displays invoice summary
* Disables case closure until invoice exists
* Handles cancellation and closed status cleanly
* Currency formatted using new helper

### 🔧 Service-case / Work Order Tabs

* Added `"Cancel"` flow with `CancelReason`
* Proper handling of cancelled MOs
* Updated system statuses:

  * Normal close → `CLOSED_POSTED`
  * Cancelled → `CLOSED_CANCELLED`

### 🪶 RepairActionModal

* Shows/hides cancel reason dynamically
* Tailored warnings for each close type

### 📄 sc-modal Pagination

* Compact 3-page sliding window
* Clearer navigation for large results

### 🧰 Utils

* Added `formatAccountingRupiah()` for IDR display

---

## 🍱 Behavioral Summary

* Stronger quotation flow
  (rejection cascades to MO/line item cancellation)
* Work Orders can now be closed **or cancelled intentionally**
* Case cannot be closed without invoice
* Owner assignments improved for all quote actions
* Cleaner UI interactions and more predictable workflow

---

## 🧪 Testing Checklist

A full list of test scenarios (quotation, invoice, WO close/cancel, pagination, modal behavior, case status updates) is included to ensure flow consistency and migration safety.

---

# 🇮🇩✨ Versi Bahasa Indonesia

> *"Sistem yang rapi adalah seperti pagi yang hening di Kyoto — teratur, jelas, dan tidak berlebihan."*

PR ini membawa peningkatan besar untuk **sistem invoice**, **alur quotation**, **penanganan case**, dan **siklus Work Order**, serta perbaikan UI yang membuat penggunaan lebih halus dan konsisten.

---

## 🌸 Ringkasan

Update ini menambahkan:

* Sistem **invoice** lengkap (DB, API, UI)
* Peningkatan logika **quotation approve/reject**, termasuk pembatalan MO
* Flow **cancel Work Order** dengan alasan
* Pembaruan status case (`CancelRepair`)
* Refactor UI (QuotationModal, CaseDetail, RepairActionModal, pagination)

---

## 🏯 Perubahan Database & Prisma

* Penambahan tabel `invoicetable`
* Penambahan field cancel pada Work Order
* Enum `CaseStatus` → tambah `CancelRepair`
* Decimal invoice dibatasi `DECIMAL(12,2)`
* Foreign key `CreatedBy` wajib → perlu backfill

---

## 🖥️ Perubahan Backend API

* Case GET lebih lengkap
* Logika PATCH Quotation diperbaiki (cancellation, owner routing, note → casenote)
* Service-log create-order kini memberi status yang benar
* Work Order PATCH mendukung cancel + alasan
* API Invoice baru (create/read/update)

---

## 🎎 Perubahan Frontend

* CM Page: tampilkan 5 case terbaru
* QuotationModal: layout lebih jelas, logic field dibersihkan
* CaseDetail: invoice summary + blokir close sebelum invoice
* Service-case: flow cancel WO lengkap
* RepairActionModal: alasan cancel ditampilkan dinamis
* Pagination sc-modal: max 3 page button
* Utility formatAccountingRupiah()

---

## 🍱 Ringkasan Perilaku

* Quotation reject kini membatalkan MO/line item terkait
* WO dapat di-close normal atau cancel
* Case tidak bisa di-close tanpa invoice
* Owner assignment lebih akurat
* UI lebih intuitif dan responsif



---

## Summary

---

## Database & Prisma changes

**Migrations**

1. **Add work order cancel fields & invoice table**

* `workorder`

  * `IsCancel BOOLEAN NOT NULL DEFAULT false`
  * `CancelReason TEXT NULL`
* New table `invoicetable`

  * `InvoiceNo VARCHAR(8) PRIMARY KEY`
  * `QuotationNo VARCHAR(8)` (FK → `quotationtable.QuotationNo`)
  * `AmountReceive DECIMAL(65,30) NOT NULL DEFAULT 0` → later limited to (12,2)
  * `AmountDiff DECIMAL(65,30) NOT NULL DEFAULT 0` → later limited to (12,2)
  * `AmountDiffReason TEXT NULL`
  * `PaymentType VARCHAR(20) NULL`
  * `AmountReceiveDate DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0)`
  * `AmountReceiveNote TEXT NULL`
  * `SendWa`, `SendEmail`, `SendInvoice`, `SendERF` as `BOOLEAN NOT NULL DEFAULT false`

2. **Extend `caseinformation` status enum**

* Alter `CaseStatus` to include `CancelRepair`
  (alongside existing statuses like `FinishRepair`, `Quote_Approved`, `Quote_Rejected`, etc.)

3. **Add `CreatedBy` to `invoicetable`**

* Column: `CreatedBy INT NOT NULL`
* FK: `invoicetable.CreatedBy` → `User.IDUser` (RESTRICT on delete, CASCADE on update)

4. **Limit invoice decimals**

* `invoicetable`

  * `AmountReceive` → `DECIMAL(12,2) NOT NULL DEFAULT 0`
  * `AmountDiff` → `DECIMAL(12,2) NOT NULL DEFAULT 0`

> ⚠️ **Migration notes**
>
> * `CreatedBy` is non-nullable — existing invoice rows must be backfilled or migration will fail.
> * Decimal downcast from `(65,30)` to `(12,2)` could truncate precision; safe only if existing values fit.

**Prisma schema**

* New `model invoicetable` with relations:

  * `quotation` → `quotationtable` (by `QuotationNo`)
  * `CreatedByUser` → `User` (`@relation("UserInvoiceAdmin")`)
* `quotationtable`

  * `invoicetable invoicetable[]`
* `User`

  * `invoicetable invoicetable[] @relation("UserInvoiceAdmin")`
* `workorder`

  * `IsCancel Boolean @default(false)`
  * `CancelReason String? @db.Text`
* `CaseStatus` enum:

  * Added `Cancel` (commented) and `CancelRepair` as valid values.

---

## Backend API changes

### Case information API

**`next-api/src/app/api/case-information/route.js`**

* `GET` now includes richer relations:

  * `materialorder` → `materialorderlineitems` with:

    * Nested `quotation_lineitem` + `quotation`
    * `owner`
  * Case `owner`

This allows UI to display quotation and owner info directly from case/material order context.

---

### Quotation PATCH logic

**`next-api/src/app/api/quotation-information/[QuotationNo]/route.js`**

Key improvements:

* **Extended line item lookup**

  * Fetches `materialorderlineitems` with related:

    * `materialorder.MOID`
    * `workorder.CaseID`, `workorder.WOID`
    * `workorder.owner` (user info: `IDUser`, `Name`, `Role`, `Username`)

* **Case & owner context**

  * Fetches `caseinformation` by `caseId` with:

    * `CaseStatus`, `Owner`, `CreatedBy`
    * `ownerUser { IDUser, Name }`
  * Resolves:

    * `oldOwnerName` from `ownerUser` or raw `Owner`
    * `newOwnerName` from `userAssign` (if provided)

* **Decision → case status mapping**

  * Preserves mapping:

    * `Approved` → `Quote_Approved`
    * `Rejected` → `Quote_Rejected`
    * else → `Pending_Quote` (or fallback `Quote_Approved` if unknown)

* **Material order cancellation**

  * Computes `rejectedLineItemIds` from `normalizedLineItems` where `approved === false`.
  * If `decisionValue === 'Rejected'`:

    * `materialorderlineitems` with affected `LineItemID` → `Status: 'Cancelled'`
    * Related `materialorder` → `OrderStatus: 'Cancelled'`
  * Else if **partially rejected**:

    * Cancel only rejected line items
    * Cancel any `materialorder` that only contains those rejected items

* **Case owner change logging (prepared)**

  * Prepares `includeChangedBy` and an `ActionLog` payload for owner changes (`model: "CaseOwner"`, `dataOld: oldOwnerName`, `dataNew: newOwnerName`).

    > Note: The `ActionLog.create` block is currently commented but now correctly reflects owner change semantics instead of status change.

* **Quotation note → casenote**

  * If `quotationNote !== null`, creates a `casenotes` entry:

    * `LogType: "System Info"`
    * `ActionType: "Quotation Request"`
    * `VisibleExternally: true`
    * `Note: quotationNote`
    * `CreatedBy`: `createdBy` or `userAssign` (parsed) if available

* **Default part approval**

  * `normalizeLineItemPayload` now sets:

    * `approved: partApproved ?? true`
      → Parts are considered **approved by default** unless explicitly rejected.

---

### Service-log order creation

**`next-api/src/app/api/service-log/create-order/route.js`**

* Adjusted notes for warranty vs. out-of-warranty:

  * `noteWarranty = isOutWarranty ? 'Request Quotation' : 'Order'`
  * Log messages:

    * Header: `"[NOTICE] Request Quotation Part"` or `"[NOTICE] Order Part"`
    * Body: `"Request Quotation Part : ..."` or `"Order Part : ..."`
* Updated assignment logging:

  * For out-of-warranty (`isOutWarranty === true`), `targetQuotation = "CM"`; otherwise `"APO"`.
  * Note line: `Requested to ${targetQuotation} : ${requestedRecipient}`
* Case status behavior:

  * Default `CaseStatus = "PartRequest"`
  * If `isOutWarranty`, set `CaseStatus = "Quote_Requested"`
* ActionLog updates:

  * `dataNew` now uses `caseUpdateData.CaseStatus` (actual new status)
  * `logDescription` reflects real status change:

    * `Edit: change status from ${previousCaseStatus} to ${caseUpdateData.CaseStatus}`

---

### Work order PATCH

**`next-api/src/app/api/work-order/[WOID]/route.js`**

* Accepts new fields from request body:

  * `CancelReason`
  * `IsCancel`
* Change-set mapping includes:

  * `CancelReason: v => v`
  * `IsCancel: v => v`

This supports closing work orders either normally or as cancelled, with a reason.

---

### Invoice API

New endpoints (Next.js API):

* `next-api/src/app/api/invoice-information/route.js`
* `next-api/src/app/api/invoice-information/[InvoiceNo]/route.js`
* `next-api/src/app/api/invoice-information/helpers.js`

High-level behavior:

* **Creation**

  * Validate payload, enforce DECIMAL(12,2) amounts.
  * Use Prisma transactions and attach `caseId` when creating invoices.
  * Store `CreatedBy` (FK to `User`).
* **Update / retrieval**

  * Read/update invoices by `InvoiceNo`.
  * Normalize data structures for UI (helpers for mapping between DB and client payload).
* **Business rules**

  * Ensure an invoice exists for a case before allowing the case to be closed (enforced in UI + flow).

---

## Frontend / UI changes

### Cash Management (CM Page)

**`test-vite/src/layout/Cm_Page.jsx`**

* Recent cases:

  * Increased from **3** to **5** most recent cases shown.
* Quotation submission owner assignment:

  * For rejected quotes, `userAssign` is now:

    * `workorder[0].OwnerID` (i.e., return ownership back to WO owner)
  * Otherwise:

    * `userAssign` remains the selected user, falling back to current `user.id`.
  * Payload built as:

    * `const targetAssignUser = payload.quoteDecision === "Rejected" ? selectedCase.caseinformation.workorder[0].OwnerID : user.id !== payload?.userAssign ? payload.userAssign : user.id`

This refines owner routing when handling quotation decisions, especially rejections.

---

### QuotationModal (form behavior & layout)

*(Diff not fully expanded here, but based on description + PR text)*

Key points:

* Refactored into a **two-column layout**, grouping related fields for clarity.
* Removed duplicate/misplaced fields and streamlined conditional field rendering.
* VAT and APO selection now conditional based on form state.
* Default `quotationNote` to `null` so backend can decide whether to create casenotes.
* `partApproved` behavior:

  * Tied more closely to quote decision; rejected decisions set `partApproved` appropriately.
* Added **dirty state tracking** and reset logic to avoid outdated values when reopening the modal.
* `useEffect` dependencies updated and a debug log added to help track form lifecycle.

---

### CaseDetail page

**`test-vite/src/pages/CaseDetail.jsx`** (large diff)

From the description and back-end changes, main updates:

* Integrates invoice fetching, submission, and display:

  * Invoice summary shown in the UI.
  * Case cannot be closed until an invoice exists.
* Supports case cancellation:

  * New UI controls for **cancel/close** case actions.
  * Checks work order / material order statuses (e.g., excludes cancelled MOs from open list).
* Uses `formatAccountingRupiah` for currency fields.
* Hooks into new invoice APIs and work order cancel/close flow.

---

### Service-case / Work Order tabs

**`test-vite/src/pages/services/service-case.jsx`**

* Local state:

  * `const [onCancelWo, setOnCancelWo] = useState(false);`

* Actions:

  * Normal close:

    * Validates, sets `onCancelWo = false`, opens `RepairActionDialog`.
  * Cancel WO:

    * New action `"Cancel WOKONTOL"` (UI label can be renamed later).
    * Validates, sets `onCancelWo = true`, opens `RepairActionDialog`.

* Material order blocking:

  * Previously: blocked closing WO if any MO `OrderStatus !== 'closed'`.
  * Now: excludes cancelled MOs too:

    * `mosNotClosed = mos.filter(mo => status !== 'closed' && status !== 'cancelled')`

* Save & close WO (`saveAndCloseWorkOrder`):

  * Determines target system status:

    * `statusTarget = onCancelWo ? "CLOSED_CANCELLED" : "CLOSED_POSTED"`
  * PATCH `/api/work-order/:WOID` with:

    * `CancelReason: repairFormData.cancelReason`
    * `SystemStatus: statusTarget`
    * `IsCancel: onCancelWo`
  * Logs case status:

    * `statusCaseTarget = onCancelWo ? "CancelRepair" : "FinishRepair"`
    * `ActionLog` and `caseinformation` both updated to `statusCaseTarget` instead of always `FinishRepair`.
  * Reset / reload flow remains unchanged.

* `RepairActionDialog` usage:

  * Passes `onCancelWo` to show/hide cancel reason, and to adjust confirmation message.

---

### RepairActionModal

**`test-vite/src/components/model/RepairActionModal.jsx`**

* Props:

  * Added `onCancelWo` (boolean) to the component.
* Form state:

  * Added `cancelReason` in `formData`.
* UI:

  * If `onCancelWo !== false`:

    * Shows `Cancel Reason` field (`Textarea`) with `span={3}` and optional required star.
* Confirm step:

  * Warning text now reflects close type:

    * **Normal:** `Status Work Order akan berubah menjadi CLOSED_POSTED`
    * **Cancel:** `Status Work Order akan berubah menjadi CLOSED_CANCEL`

This ties the modal UX directly to whether we're closing or cancelling the work order.

---

### sc-modal pagination

**`test-vite/src/components/model/sc-modal.jsx`**

* Introduced `MAX_PAGES_SHOWN = 3`.
* Helper `getPaginationPages()`:

  * If `totalPages <= 3`: `[1..totalPages]`
  * If `currentPage <= 2`: `[1,2,3]`
  * If `currentPage >= totalPages - 1`: `[totalPages-2, totalPages-1, totalPages]`
  * Else: `[currentPage-1, currentPage, currentPage+1]`
* Uses `paginationPages` instead of naïvely rendering buttons for all pages.

This keeps the pagination compact and easier to navigate when there are many pages.

---

### Utils

**`test-vite/src/lib/utils.js`**

* Added `formatAccountingRupiah(value)`:

  ```js
  export function formatAccountingRupiah(value) {
    if (value == null || value === "") return "---";
    return new Intl.NumberFormat("id-ID", {
      style: "currency",
      currency: "IDR",
      minimumFractionDigits: 0,
    }).format(value);
  }
  ```
* Used for currency display in CaseDetail and related components.

---

## Behavioral summary

* **Case & quotation**

  * Cases now reflect quotation decisions more accurately (approved, rejected, pending).
  * Rejected quotations:

    * Cancel related material orders & line items.
    * Route owner assignment back appropriately on rejection.
    * Log quotation notes into case notes when provided.

* **Invoices**

  * New `invoicetable` schema with proper relations and decimal limits.
  * Next.js APIs for create/read/update with validation and transactions.
  * Integrated into CaseDetail; case closure requires an invoice and shows an invoice summary.

* **Work orders & cancellation**

  * Work orders can now be cancelled with a reason:

    * Backend fields: `IsCancel`, `CancelReason`, `SystemStatus`.
    * Frontend flows: separate “close” vs. “cancel” paths with tailored warnings.
  * Case status updated to `CancelRepair` when cancelling WO, `FinishRepair` otherwise.

* **UI/UX**

  * QuotationModal layout and logic cleaned up.
  * Pagination limited to max 3 visible pages.
  * Cash management shows 5 recent cases.
  * Currency fields display in proper IDR accounting format.

---

## Risks & considerations

* **Data migration**

  * Need a data backfill for `invoicetable.CreatedBy`.
  * Decimal shrink for invoice amounts — confirm existing data fits `[0..9999999999.99]`.

* **Status compatibility**

  * New `CaseStatus` value `CancelRepair` and `Cancel` (enum) must be handled in any external integrations or reports.
  * New `SystemStatus` values like `CLOSED_CANCELLED` must be supported in any downstream consumers.

* **Behavior changes**

  * Default `partApproved = true` may alter old flows; double-check that UIs correctly flag rejected items and that users understand the new default.

---

## Testing checklist

* [ ] Run all Prisma migrations successfully in a staging environment.
* [ ] Create a quotation (in/out warranty), approve → ensure:

  * [ ] Case status updates as expected.
  * [ ] Material orders remain active.
* [ ] Reject a quotation with:

  * [ ] All items rejected → all relevant MOs & line items cancelled.
  * [ ] Partial rejection → only relevant MOs cancelled.
  * [ ] Owner assignment after rejection matches WO owner.
  * [ ] Quotation note creates a casenote.
* [ ] Create and update invoices:

  * [ ] Validation errors handled correctly.
  * [ ] Amounts stored with 2 decimal places.
  * [ ] `CreatedBy` correctly populated.
* [ ] CaseDetail:

  * [ ] Case cannot be closed without an invoice.
  * [ ] Invoice summary renders correctly.
  * [ ] Currency uses `formatAccountingRupiah`.
* [ ] Work order close vs cancel:

  * [ ] Normal close → `SystemStatus = CLOSED_POSTED`, case status `FinishRepair`.
  * [ ] Cancel WO → `SystemStatus = CLOSED_CANCELLED`, `IsCancel = true`, `CancelReason` stored, case status `CancelRepair`.
  * [ ] Attempting close with open (non-cancelled, non-closed) MOs is blocked.
* [ ] QuotationModal:

  * [ ] Two-column layout renders correctly.
  * [ ] VAT/APO conditional fields work as expected.
  * [ ] Dirty state tracking and reset logic behave when reopening the modal.
* [ ] sc-modal pagination:

  * [ ] With >3 pages, shows max 3 page buttons centered around current page.
* [ ] CM Page:

  * [ ] Shows 5 most recent cases in correct order.
